### PR TITLE
chore: update .arg

### DIFF
--- a/.arg
+++ b/.arg
@@ -1,3 +1,6 @@
+# Refer to the README file for variable descriptions.
+# Change the variables below to customize the build process.
+
 CUSTOM_TAG=demo
 IMAGE_REGISTRY=ttl.sh
 OS_DISTRIBUTION=ubuntu
@@ -6,14 +9,6 @@ OS_VERSION=22
 K8S_DISTRIBUTION=k3s
 ISO_NAME=palette-edge-installer
 
-
-# CUSTOM_TAG-------------------------Environment name for provider image naming
-# IMAGE_REGISTRY---------------------Image Registry Name
-# OS_DISTRIBUTION--------------------OS Distribution (ubuntu, opensuse-leap)
-# IMAGE_REPOSITORY-------------------Image Repository Name
-# OS_VERSION-------------------------OS Version, only applies to Ubuntu (20, 22)
-# K8S_DISTRIBUTION-------------------Kubernetes Distribution (k3s, rke2, kubeadm)
-# ISO Name---------------------------Name of the Installer ISO
 
 
 


### PR DESCRIPTION
@3pings in the user experience section today. Some of the users got confused on where to update the `.arg` file. Some updated the comments section. Now that the README contains a markdown table with variable descriptions. I think we can prevent confusion by removing the extra content from the `.arg` file.


The `.arg` file would look like this:

```
# Refer to the README file for variable descriptions.
# Change the variables below to customize the build process.

CUSTOM_TAG=demo
IMAGE_REGISTRY=ttl.sh
OS_DISTRIBUTION=ubuntu
IMAGE_REPO=$OS_DISTRIBUTION
OS_VERSION=22   
K8S_DISTRIBUTION=k3s
ISO_NAME=palette-edge-installer
```
