### PR TITLE
PE-2605 Adding apparmor-parser as se_linux is disabled

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -243,6 +243,13 @@ base-image:
         RUN zypper cc && \
             zypper clean
     END
+
+    IF [ "$OS_DISTRIBUTION" = "opensuse-leap" ]
+        RUN zypper install -y apparmor-parser apparmor-profiles
+        RUN zypper cc && \
+            zypper clean
+    END
+
     IF [ "$ARCH" = "arm64" ]
         RUN mkdir -p /etc/luet/repos.conf.d && luet repo add spectro --type docker --url gcr.io/spectro-dev-public/luet-repo-arm --priority 1 -y && luet repo update
     ELSE IF [ "$ARCH" = "amd64" ]


### PR DESCRIPTION
If `se_linux=0` is disabled, then `apparmour` has to be present so that containerd can create containers.