### PR TITLE
Updated SLEM build script for Kairos v2.4.3

### DIFF
--- a/slem/Dockerfile
+++ b/slem/Dockerfile
@@ -1,9 +1,6 @@
 ARG BASE_IMAGE=registry.suse.com/suse/sle-micro-rancher/5.4:latest
 FROM $BASE_IMAGE
 
-RUN zypper ar -G https://download.opensuse.org/repositories/utilities/openSUSE_Factory/utilities.repo || true && \
-    zypper ref
-
 ADD repos/SUSE* /etc/zypp/repos.d/
 ADD services/* /etc/zypp/services.d/
 RUN zypper --gpg-auto-import-keys ref
@@ -15,7 +12,9 @@ RUN zypper in --force-resolution -y \
     polkit \
     rng-tools \
     nano \
+    growpart \
     && zypper cc
+
 ADD repos/opensuse* /etc/zypp/repos.d/
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper in --force-resolution -y --no-allow-vendor-change \
@@ -28,63 +27,11 @@ RUN zypper in --force-resolution -y --no-allow-vendor-change \
 RUN mkdir -p /run/lock
 RUN mkdir -p /usr/libexec
 RUN touch /usr/libexec/.keep
+
 COPY --from=quay.io/kairos/framework:v2.4.3_generic / /
 
-RUN mkdir -p /etc/dnf
-RUN echo "install_weak_deps=False" > /etc/dnf/dnf.conf
-
-RUN zypper in --force-resolution -y \
-    bash-completion \
-    conntrack-tools \
-    coreutils \
-    curl \
-    device-mapper \
-    dhcp-client \
-    dosfstools \
-    dracut \
-    e2fsprogs \
-    fail2ban \
-    findutils \
-    gawk \
-    growpart \
-    gptfdisk \
-    haveged \
-    htop \
-    iproute2 \
-    iptables \
-    iputils \
-    issue-generator \
-    jq \
-    less \
-    logrotate \
-    lsscsi \
-    lvm2 \
-    mdadm \
-    multipath-tools \
-    nano \
-    nohang \
-    open-iscsi \
-    openssh \
-    open-vm-tools \
-    parted \
-    pigz \
-    policycoreutils \
-    polkit \
-    procps \
-    rng-tools \
-    rsync \
-    squashfs \
-    strace \
-    sudo \
-    systemd \
-    systemd-network \
-    tar \
-    timezone \
-    tmux \
-    vim \
-    which \
-    tpm2* \
-    && zypper cc
+# Remove file below to allow dracut to build initrd without dhcp-client
+RUN rm -rf /usr/lib/dracut/modules.d/35network-legacy
 
 ## Generate initrd
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
@@ -93,6 +40,8 @@ RUN kernel=$(ls /lib/modules | head -n1) && \
             dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
             ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
 RUN kernel=$(ls /lib/modules | head -n1) && dracut -f "/boot/initrd-${kernel}" "${kernel}" && ln -sf "initrd-${kernel}" /boot/initrd
+
+# Cleanup
 RUN rm -rf /boot/initramfs-*
 RUN rm -rf /etc/zypp/repos.d/*
 RUN rm -rf /etc/zypp/services.d/*

--- a/slem/Dockerfile
+++ b/slem/Dockerfile
@@ -64,7 +64,7 @@ RUN zypper in --force-resolution -y \
     open-vm-tools \
     parted \
     pigz \
-    policycoreutils \
+#    policycoreutils \
     polkit \
     procps \
     rng-tools \
@@ -80,7 +80,7 @@ RUN zypper in --force-resolution -y \
     vim \
     which \
     tpm2* \
-    && zypper cc \
+    && zypper cc
 
 ## Generate initrd
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \

--- a/slem/Dockerfile
+++ b/slem/Dockerfile
@@ -1,5 +1,9 @@
 ARG BASE_IMAGE=registry.suse.com/suse/sle-micro-rancher/5.4:latest
 FROM $BASE_IMAGE
+
+RUN zypper ar -G https://download.opensuse.org/repositories/utilities/openSUSE_Factory/utilities.repo || true && \
+    zypper ref
+
 ADD repos/SUSE* /etc/zypp/repos.d/
 ADD services/* /etc/zypp/services.d/
 RUN zypper --gpg-auto-import-keys ref
@@ -24,7 +28,7 @@ RUN zypper in --force-resolution -y --no-allow-vendor-change \
 RUN mkdir -p /run/lock
 RUN mkdir -p /usr/libexec
 RUN touch /usr/libexec/.keep
-COPY --from=quay.io/kairos/framework:v2.4.3_opensuse-leap / /
+COPY --from=quay.io/kairos/framework:v2.4.3_generic / /
 
 RUN mkdir -p /etc/dnf
 RUN echo "install_weak_deps=False" > /etc/dnf/dnf.conf
@@ -58,13 +62,13 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
-#    nohang \
+    nohang \
     open-iscsi \
     openssh \
     open-vm-tools \
     parted \
     pigz \
-#    policycoreutils \
+    policycoreutils \
     polkit \
     procps \
     rng-tools \

--- a/slem/README.md
+++ b/slem/README.md
@@ -1,6 +1,9 @@
-# slem
+# SUSE Linux Enterprise Micro
 
-slem base image needs to built on the slem server.
-A registration code is need to build the slem base image.
+## Pre-requisites :
+* A host with `Docker`, SLES Micro installed
+* Registration code to register with SUSE
+* If you wish to override the BASE_IMAGE, make sure to use a container image that has zypper installed in it 
 
+## Steps to build the image:
 ./build.sh <REGISTRATION_CODE>

--- a/slem/README.md
+++ b/slem/README.md
@@ -1,8 +1,8 @@
 # SUSE Linux Enterprise Micro
 
 ## Pre-requisites :
-* A host with `Docker`, SLES Micro installed
-* Registration code to register with SUSE
+* A host with SLES Micro distribution installed
+* Registration code to register with SUSEConnect
 * If you wish to override the BASE_IMAGE, make sure to use a container image that has zypper installed in it 
 
 ## Steps to build the image:

--- a/slem/build.sh
+++ b/slem/build.sh
@@ -6,9 +6,10 @@ if [[ -z "$1" ]]; then
   echo "Example : ./build.sh 123456789"
   exit 1
 fi
+REGISTRATION_CODE=$1
 
 set -ex
-REGISTRATION_CODE=$1
+
 mkdir -p /var/slem
 yes | cp ./Dockerfile /var/slem
 cd /var/slem
@@ -22,6 +23,7 @@ cp /etc/zypp/repos.d/SUSE*.repo .
 cd ../../services/
 cp /etc/zypp/services.d/*.service .
 cd ../repos/opensuse/
+
 cat > opensuse-oss.repo <<EOF
 [opensuse-oss]
 enabled=1
@@ -29,10 +31,10 @@ autorefresh=0
 baseurl=http://download.opensuse.org/distribution/leap/15.5/repo/oss/
 EOF
 cd ../..
+
 #SUSEConnect -r $REGISTRATION_CODE
 transactional-update register -r $REGISTRATION_CODE
-systemctl restart docker
 transactional-update -n pkg install docker
-transactional-update -n register -p PackageHub/15.4/x86_64
-docker build -t slem-base-image:v243 .
+#transactional-update -n register -p PackageHub/15.4/x86_64
 
+docker build -t gcr.io/spectro-dev-public/boobalan/slem-base-image:v243 .

--- a/slem/build.sh
+++ b/slem/build.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-set -ex
+if [[ -z "$1" ]]; then
+  echo "ERROR : Registration code is empty !"
+  echo "Re-run this utility with SUSE Registration code in the args."
+  echo "Example : ./build.sh 123456789"
+  exit 1
+fi
 
+set -ex
 REGISTRATION_CODE=$1
-mkdir /var/slem
+mkdir -p /var/slem
+yes | cp ./Dockerfile /var/slem
 cd /var/slem
-mkdir repos
-mkdir services
+mkdir -p repos
+mkdir -p services
 cd repos/
-mkdir SUSE
-mkdir opensuse
+mkdir -p SUSE
+mkdir -p opensuse
 cd SUSE
 cp /etc/zypp/repos.d/SUSE*.repo .
 cd ../../services/
@@ -22,7 +29,8 @@ autorefresh=0
 baseurl=http://download.opensuse.org/distribution/leap/15.5/repo/oss/
 EOF
 cd ../..
-SUSEConnect -r $REGISTRATION_CODE
+#SUSEConnect -r $REGISTRATION_CODE
+transactional-update register -r $REGISTRATION_CODE
 systemctl restart docker
 transactional-update -n pkg install docker
 transactional-update -n register -p PackageHub/15.4/x86_64

--- a/slem/build.sh
+++ b/slem/build.sh
@@ -37,4 +37,4 @@ transactional-update register -r $REGISTRATION_CODE
 transactional-update -n pkg install docker
 #transactional-update -n register -p PackageHub/15.4/x86_64
 
-docker build -t gcr.io/spectro-dev-public/boobalan/slem-base-image:v243 .
+docker build -t slem-base-image:kairos-v2.4.3_generic .

--- a/slem/build.sh
+++ b/slem/build.sh
@@ -35,6 +35,5 @@ cd ../..
 #SUSEConnect -r $REGISTRATION_CODE
 transactional-update register -r $REGISTRATION_CODE
 transactional-update -n pkg install docker
-#transactional-update -n register -p PackageHub/15.4/x86_64
 
-docker build -t slem-base-image:kairos-v2.4.3_generic .
+docker build -t slem-base:kairos-v2.4.3 .


### PR DESCRIPTION
This script incorporates the changes for Kairos framework v2.4.3 & also takes into consideration the feedback we got from SUSE Rancher about the base image we've built with Kairos components. 

Feedback from SUSE:

We’ve had a look through the Dockerfile, along with the further details in the slides that you’ve shared with us, and we have a few concerns that I think are easily remedied:

1. We need you to build the image on a SLE Micro host, as what you’ve essentially done here is mixed SLES with SLE Micro from a package repo perspective, and whilst this will functionally work, it makes it much more challenging for us to support.
2. Following (1), we realise that when building on a SLE Micro host that you won’t have access to all the necessary packages, so we suggest that you pull the extra dependencies from OpenSUSE Leap 15.4 repos (http://download.opensuse.org/distribution/leap/15.4/repo/oss/ - these are binary compatible with SLES) – we’re happy to support the ~30 extra packages that are deployed from this repo.
3. You’re pulling in `dhcp-client` which pulls in several extra dependencies that may not be needed as DHCP is already taken care of by NetworkManager, which is installed by default… can we drop this requirement? I do note that your Kairos framework image creates a dracut requirement for the network-legacy
4. module (via /etc/dracut.conf.d/90-kairos-network-legacy.conf), but I’m wondering how essential this is to Kairos functioning if NetworkManager is available?
5. Can you explain why containerd is pulled in outside of k3s? Are you running additional containers on the host, outside of k3s? If so, are you pulling containerd from SLE repos, or is this something you’re providing and supporting yourselves?