### PR TITLE
Include SUSE PackageHub repos for additional packages

### DIFF
--- a/slem/build.sh
+++ b/slem/build.sh
@@ -35,5 +35,6 @@ cd ../..
 #SUSEConnect -r $REGISTRATION_CODE
 transactional-update register -r $REGISTRATION_CODE
 transactional-update -n pkg install docker
+transactional-update -n register -p PackageHub/15.5/x86_64
 
 docker build -t slem-base:kairos-v2.4.3 .


### PR DESCRIPTION
Dockerfile attempts to include the following packages which are not part of SLEM repo. 

- nano
- systemd-network
- rng-tools

This PR has the fix to include the additional SUSE package repos for installing these packages