### PR TITLE
Update Earthly to 0.8.5

### DIFF
--- a/earthly.sh
+++ b/earthly.sh
@@ -26,7 +26,7 @@ function build_without_proxy() {
 
 global_config="{disable_analytics: true}"
 PE_VERSION=$(git describe --abbrev=0 --tags)
-EARTHLY_VERSION=v0.7.4
+EARTHLY_VERSION=v0.8.5
 source .arg
 
 ### Verify Depencies


### PR DESCRIPTION
Please copy:
* `earthly/earthly:v0.8.5` to `gcr.io/spectro-images-public/earthly/earthly:v0.8.5`
* `earthly/buildkitd:v0.8.5` to `gcr.io/spectro-images-public/earthly/buildkitd:v0.8.5`

and then merge this PR. This uses the latest version of Earthly to reduce the number of CVEs in resulting images