### PR TITLE
disable cis_hardening

### DIFF
--- a/.arg.template
+++ b/.arg.template
@@ -11,7 +11,7 @@ HTTP_PROXY=
 PROXY_CERT_PATH=
 UPDATE_KERNEL=false
 CLUSTERCONFIG=spc.tgz
-CIS_HARDENING=true
+CIS_HARDENING=false
 
 # If you have Ubuntu Pro, use the UBUNTU_PRO_KEY variable to activate it as part of the image build
 # UBUNTU_PRO_KEY=your-key


### PR DESCRIPTION
cis_hardening needs to be enabled by the user and is disabled by default.