### PR TITLE
Environment variable to configure insecure/untrusted registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,31 @@ cp spectro-luet-auth.yaml.template spectro-luet-auth.yaml
 ```shell
 earthly --push +build-all-images
 ```
+
+### Using untrusted or insecure registries for Base Images
+
+During execution process Earthly pulls Base Images (specified as `BASE_IMAGE` in .arg file) from external registries. By default, it connects to the registry via HTTPS protocol using trusted CA installed inside the container. For the cases where external registry exposed via plain HTTP or HTTPs with self-signed certificates, it is possible to configured Earthly buildkit to use HTTP or ignore untrusted certificates by using environment variable `EARTHLY_ADDITIONAL_BUILDKIT_CONFIG`. 
+
+For registries exposed via HTTP, use the following commands:
+```shell
+$ export EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="
+[registry.\"10.10.131.24:5000\"]
+  http = true
+"
+$ earthly --push +build-all-images
+```
+
+For registries exposed via HTTPs with self-signed certificates, use the following commands:
+```shell
+$ export EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="
+[registry.\"10.10.131.24:5000\"]
+  insecure = true
+"
+$ earthly --push +build-all-images
+```
+
+If this configuration is no longer required, unset the variable:
+
+```shell
+$ unset EARTHLY_ADDITIONAL_BUILDKIT_CONFIG
+```

--- a/earthly.sh
+++ b/earthly.sh
@@ -11,17 +11,17 @@ function build_with_proxy() {
         docker stop earthly-buildkitd
     fi
     # start earthly buildkitd
-    docker run -d --privileged --name earthly-buildkitd -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm -t -e GLOBAL_CONFIG="$global_config" -e BUILDKIT_TCP_TRANSPORT_ENABLED=true -e http_proxy=$HTTP_PROXY -e https_proxy=$HTTPS_PROXY -e HTTPS_PROXY=$HTTPS_PROXY -e HTTP_PROXY=$HTTP_PROXY -e NO_PROXY=$NO_PROXY -e no_proxy=$no_proxy -e EARTHLY_GIT_CONFIG=$gitconfig -v "$PROXY_CERT_PATH:/usr/local/share/ca-certificates/sc.crt:ro" -v earthly-tmp:/tmp/earthly:rw -p 8372:8372 $SPECTRO_PUB_REPO/earthly/buildkitd:$EARTHLY_VERSION
+    docker run -d --privileged --name earthly-buildkitd -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm -t -e GLOBAL_CONFIG="$global_config" -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -e BUILDKIT_TCP_TRANSPORT_ENABLED=true -e http_proxy=$HTTP_PROXY -e https_proxy=$HTTPS_PROXY -e HTTPS_PROXY=$HTTPS_PROXY -e HTTP_PROXY=$HTTP_PROXY -e NO_PROXY=$NO_PROXY -e no_proxy=$no_proxy -e EARTHLY_GIT_CONFIG=$gitconfig -v "$PROXY_CERT_PATH:/usr/local/share/ca-certificates/sc.crt:ro" -v earthly-tmp:/tmp/earthly:rw -p 8372:8372 $SPECTRO_PUB_REPO/earthly/buildkitd:$EARTHLY_VERSION
     # Update the CA certificates in the container
     docker exec -it earthly-buildkitd update-ca-certificates
 
     # Run Earthly in Docker to create artifacts  Variables are passed from the .arg file
-    docker run --privileged -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -e GLOBAL_CONFIG="$global_config" -e EARTHLY_BUILDKIT_HOST=tcp://0.0.0.0:8372 -e BUILDKIT_TLS_ENABLED=false -v "$(pwd)":/workspace -v "$PROXY_CERT_PATH:/workspace/sc.crt:ro" $SPECTRO_PUB_REPO/earthly/earthly:$EARTHLY_VERSION --allow-privileged "$@"
+    docker run --privileged -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -e GLOBAL_CONFIG="$global_config" -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -e EARTHLY_BUILDKIT_HOST=tcp://0.0.0.0:8372 -e BUILDKIT_TLS_ENABLED=false -v "$(pwd)":/workspace -v "$PROXY_CERT_PATH:/workspace/sc.crt:ro" $SPECTRO_PUB_REPO/earthly/earthly:$EARTHLY_VERSION --allow-privileged "$@"
 }
 
 function build_without_proxy() {
     # Run Earthly in Docker to create artifacts  Variables are passed from the .arg file
-    docker run --privileged -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -e GLOBAL_CONFIG="$global_config" -v "$(pwd)":/workspace $SPECTRO_PUB_REPO/earthly/earthly:$EARTHLY_VERSION --allow-privileged "$@"
+    docker run --privileged -v ~/.docker/config.json:/root/.docker/config.json -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -e GLOBAL_CONFIG="$global_config" -e EARTHLY_ADDITIONAL_BUILDKIT_CONFIG -v "$(pwd)":/workspace $SPECTRO_PUB_REPO/earthly/earthly:$EARTHLY_VERSION --allow-privileged "$@"
 }
 
 global_config="{disable_analytics: true}"


### PR DESCRIPTION
Adding variable `EARTHLY_ADDITIONAL_BUILDKIT_CONFIG` for earthly.sh script to allow earthly pull Base OS images from insecure/untrusted registries.