### PR TITLE
RHEL 9 Dockerfile + RHEL8/9 Dockerfiles to build with RH Satellite

### DIFF
--- a/rhel-core-images/Dockerfile.rhel8.sat
+++ b/rhel-core-images/Dockerfile.rhel8.sat
@@ -1,0 +1,100 @@
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-init:8.7-10
+ARG KAIROS_FRAMEWORK_IMAGE=quay.io/kairos/framework:v2.7.41
+
+FROM $KAIROS_FRAMEWORK_IMAGE as kairosframework
+
+FROM $BASE_IMAGE 
+
+ARG KAIROS_FRAMEWORK_IMAGE
+ARG ORGNAME
+ARG KEYNAME
+ARG SATHOSTNAME
+
+RUN dnf config-manager --disable ubi-8-appstream-rpms ubi-8-baseos-rpms ubi-8-codeready-builder-rpms
+RUN rm /etc/rhsm-host
+RUN rpm -Uvh http://${SATHOSTNAME}/pub/katello-ca-consumer-latest.noarch.rpm
+RUN subscription-manager register --org=${ORGNAME} --activationkey=${KEYNAME}
+
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+# Generate machine-id because https://bugzilla.redhat.com/show_bug.cgi?id=1737355#c6
+RUN uuidgen > /etc/machine-id && dnf install -y \
+    squashfs-tools \ 
+    dracut-live \
+    livecd-tools \
+    dracut-squash \
+    dracut-network \
+    efibootmgr \
+    dhclient \
+    audit \
+    sudo \
+    systemd \
+    systemd-networkd \
+    systemd-timesyncd \
+    parted \
+    dracut \
+    e2fsprogs \
+    dosfstools \
+    coreutils-single \
+    device-mapper \
+    grub2 \
+    which \
+    curl \
+    nano \
+    gawk \
+    haveged \
+    polkit \
+    ncurses \
+    tar \
+    kbd \
+    lvm2 \
+    zstd \
+    openssh-server \
+    openssh-clients \
+    shim-x64 \
+    grub2-pc \
+    grub2-efi-x64 \
+    grub2-efi-x64-modules \
+    open-vm-tools \
+    iscsi-initiator-utils \
+    iptables ethtool socat iproute-tc conntrack \
+    kernel kernel-modules kernel-modules-extra \
+    rsync jq && dnf clean all
+
+
+COPY --from=kairosframework / /
+
+RUN sed -i 's/\bsource\b/./g' /system/oem/00_rootfs.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/09_openrc_services.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/50_recovery.yaml
+
+RUN mkdir -p /run/lock
+RUN touch /usr/libexec/.keep
+
+
+# Configure the box. The ubi image masks services for containers, we unmask them 
+RUN systemctl list-unit-files |grep masked |cut -f 1 -d " " | xargs systemctl unmask
+RUN systemctl enable getty@tty1.service
+RUN systemctl enable getty@tty2.service
+RUN systemctl enable getty@tty3.service
+RUN systemctl enable systemd-networkd
+RUN systemctl enable systemd-resolved
+RUN systemctl enable sshd
+RUN systemctl disable selinux-autorelabel-mark.service 
+#RUN systemctl enable tmp.mount
+
+COPY overlay/rhel8/ /
+
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
+            ln -sf "${kernel#/boot/}" /boot/vmlinuz
+RUN kernel=$(ls /lib/modules | head -n1) && \
+            dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
+            ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
+RUN rm -rf /boot/initramfs-*
+
+RUN envsubst >>/etc/os-release </usr/lib/os-release.tmpl
+RUN mkdir -p /etc/luet/repos.conf.d
+## Clear cache
+RUN rm -rf /var/cache/* && journalctl --vacuum-size=1K  && rm /etc/machine-id
+
+
+RUN subscription-manager unregister

--- a/rhel-core-images/Dockerfile.rhel9
+++ b/rhel-core-images/Dockerfile.rhel9
@@ -1,0 +1,96 @@
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9-init:9.4-6
+
+FROM $BASE_IMAGE 
+ARG USERNAME
+ARG PASSWORD
+
+RUN dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -y
+# Subscription manager in redhat does not run directly in containers unless you run on a redhat host, hence we remove the rhsm-host, login to the redhat subscription and add the repos
+RUN rm /etc/rhsm-host && subscription-manager register --username ${USERNAME} --password ${PASSWORD} \
+  && yum repolist \
+  && subscription-manager attach --auto \
+  && subscription-manager repos --enable rhel-9-for-x86_64-appstream-rpms \
+  && yum repolist
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+# Generate machine-id because https://bugzilla.redhat.com/show_bug.cgi?id=1737355#c6
+RUN uuidgen > /etc/machine-id && dnf install -y \
+    squashfs-tools \ 
+    dracut-live \
+    livecd-tools \
+    dracut-squash \
+    dracut-network \
+    efibootmgr \
+    dhclient \
+    audit \
+    sudo \
+    systemd \
+    systemd-networkd \
+    systemd-timesyncd \
+    systemd-resolved \    
+    parted \
+    dracut \
+    e2fsprogs \
+    dosfstools \
+    coreutils-single \
+    device-mapper \
+    grub2 \
+    which \
+    nano \
+    gawk \
+    haveged \
+    polkit \
+    ncurses \
+    tar \
+    kbd \
+    lvm2 \
+    zstd \
+    openssh-server \
+    openssh-clients \
+    shim-x64 \
+    grub2-pc \
+    grub2-efi-x64 \
+    grub2-efi-x64-modules \
+    open-vm-tools \
+    iscsi-initiator-utils \
+    iptables ethtool socat iproute-tc conntrack \
+    kernel kernel-modules kernel-modules-extra \
+    rsync jq && dnf clean all
+
+
+COPY --from=quay.io/kairos/framework:v2.7.41 / /
+
+RUN sed -i 's/\bsource\b/./g' /system/oem/00_rootfs.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/09_openrc_services.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/50_recovery.yaml
+
+RUN mkdir -p /run/lock
+RUN touch /usr/libexec/.keep
+
+
+# Configure the box. The ubi image masks services for containers, we unmask them 
+RUN systemctl list-unit-files |grep masked |cut -f 1 -d " " | xargs systemctl unmask
+RUN systemctl enable getty@tty1.service
+RUN systemctl enable getty@tty2.service
+RUN systemctl enable getty@tty3.service
+RUN systemctl enable systemd-networkd
+RUN systemctl enable systemd-resolved
+RUN systemctl enable sshd
+RUN systemctl disable selinux-autorelabel-mark.service 
+#RUN systemctl enable tmp.mount
+
+COPY overlay/rhel9/ /
+
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
+            ln -sf "${kernel#/boot/}" /boot/vmlinuz
+RUN kernel=$(ls /lib/modules | head -n1) && \
+            dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
+            ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
+RUN rm -rf /boot/initramfs-*
+
+RUN envsubst >>/etc/os-release </usr/lib/os-release.tmpl
+RUN mkdir -p /etc/luet/repos.conf.d
+## Clear cache
+RUN rm -rf /var/cache/* && journalctl --vacuum-size=1K  && rm /etc/machine-id
+
+
+RUN subscription-manager unregister

--- a/rhel-core-images/Dockerfile.rhel9.sat
+++ b/rhel-core-images/Dockerfile.rhel9.sat
@@ -1,0 +1,99 @@
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9-init:9.4-6
+ARG KAIROS_FRAMEWORK_IMAGE=quay.io/kairos/framework:v2.7.41
+
+FROM $KAIROS_FRAMEWORK_IMAGE as kairosframework
+
+FROM $BASE_IMAGE 
+
+ARG KAIROS_FRAMEWORK_IMAGE
+ARG ORGNAME
+ARG KEYNAME
+ARG SATHOSTNAME
+
+RUN dnf config-manager --disable ubi-9-appstream-rpms ubi-9-baseos-rpms ubi-9-codeready-builder
+RUN rm /etc/rhsm-host
+RUN rpm -Uvh http://${SATHOSTNAME}/pub/katello-ca-consumer-latest.noarch.rpm
+RUN subscription-manager register --org=${ORGNAME} --activationkey=${KEYNAME}
+
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+# Generate machine-id because https://bugzilla.redhat.com/show_bug.cgi?id=1737355#c6
+RUN uuidgen > /etc/machine-id && dnf install -y \
+    squashfs-tools \ 
+    dracut-live \
+    livecd-tools \
+    dracut-squash \
+    dracut-network \
+    efibootmgr \
+    dhclient \
+    audit \
+    sudo \
+    systemd \
+    systemd-networkd \
+    systemd-timesyncd \
+    systemd-resolved \    
+    parted \
+    dracut \
+    e2fsprogs \
+    dosfstools \
+    coreutils-single \
+    device-mapper \
+    grub2 \
+    which \
+    nano \
+    gawk \
+    haveged \
+    polkit \
+    ncurses \
+    tar \
+    kbd \
+    lvm2 \
+    zstd \
+    openssh-server \
+    openssh-clients \
+    shim-x64 \
+    grub2-pc \
+    grub2-efi-x64 \
+    grub2-efi-x64-modules \
+    open-vm-tools \
+    iscsi-initiator-utils \
+    iptables ethtool socat iproute-tc conntrack \
+    kernel kernel-modules kernel-modules-extra \
+    rsync jq && dnf clean all
+
+COPY --from=kairosframework / /
+
+RUN sed -i 's/\bsource\b/./g' /system/oem/00_rootfs.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/09_openrc_services.yaml
+RUN sed -i 's/\bsource\b/./g' /system/oem/50_recovery.yaml
+
+RUN mkdir -p /run/lock
+RUN touch /usr/libexec/.keep
+
+
+# Configure the box. The ubi image masks services for containers, we unmask them 
+RUN systemctl list-unit-files |grep masked |cut -f 1 -d " " | xargs systemctl unmask
+RUN systemctl enable getty@tty1.service
+RUN systemctl enable getty@tty2.service
+RUN systemctl enable getty@tty3.service
+RUN systemctl enable systemd-networkd
+RUN systemctl enable systemd-resolved
+RUN systemctl enable sshd
+RUN systemctl disable selinux-autorelabel-mark.service 
+#RUN systemctl enable tmp.mount
+
+COPY overlay/rhel9/ /
+
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
+            ln -sf "${kernel#/boot/}" /boot/vmlinuz
+RUN kernel=$(ls /lib/modules | head -n1) && \
+            dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
+            ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
+RUN rm -rf /boot/initramfs-*
+
+RUN envsubst >>/etc/os-release </usr/lib/os-release.tmpl
+RUN mkdir -p /etc/luet/repos.conf.d
+## Clear cache
+RUN rm -rf /var/cache/* && journalctl --vacuum-size=1K  && rm /etc/machine-id
+
+
+RUN subscription-manager unregister

--- a/rhel-core-images/README.md
+++ b/rhel-core-images/README.md
@@ -1,0 +1,81 @@
+# Kairos RHEL 8 and RHEL 9 images
+
+## Build the image using Red Hat Subscription
+
+Follow steps below to execute the build process on the host with access to Red Hat Subscription Management system (redhat.com) and by using Red Hat username and password.
+
+To build the image provide username and password for Red Hat Subscription Manager to register the system and install packages during the build process.
+
+To build RHEL 8 Kairos Image, execute:
+```
+docker build -t <local-registry>/<image>:<image-tag> --build-arg USERNAME=<RHSM username> --build-arg PASSWORD='<RHSM password>' -f Dockerfile.rhel8.
+```
+
+To build RHEL 9 Kairos Image, execute:
+```
+docker build -t <local-registry>/<image>:<image-tag> --build-arg USERNAME=<RHSM username> --build-arg PASSWORD='<RHSM password>' -f Dockerfile.rhel9 .
+```
+
+**In case of any errors during package installation steps - these errors might be cause by previous build attempts. Execute `docker build` command again by providing argument `--no-cache` to build the image from scratch**
+
+## Build the image using Red Hat Satellite and mirrored repositories
+
+This scenario is for the environment where Red Hat Satellite must be used and access to public Red Hat repositories is not possible. For this case use Dockerfiles `Dockerfile.rhel9.sat` and `Dockerfile.rhel8.sat` - these files are modified to use Red Hat Satellite Activation key to register host and install all required packages.
+
+### Prerequisites
+
+1. Mirror base RHEL UBI image (`registry.access.redhat.com/ubi9-init:9.4-6`) to the internal Container registry. Provide image path for the build process by using argument `BASE_IMAGE`. 
+
+2. Mirror Kairos framework image (`quay.io/kairos/framework:v2.7.41`) to the internal Container registry. Provide image path for the build process by using argument `KAIROS_FRAMEWORK_IMAGE`. 
+
+3. Have the following repostiories synced and available on Red Hat Satellite:
+
+For RHEL9:
+* rhel-9-for-x86_64-appstream-rpms
+* rhel-9-for-x86_64-baseos-rpms
+* EPEL9 (upstream URL https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/)
+
+For RHEL8:
+* rhel-8-for-x86_64-appstream-rpms
+* rhel-8-for-x86_64-baseos-rpms
+* EPEL8 (upstream URL https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/)
+
+
+4. Create Activation Key in RH Satellite and add corresponding repositories listed above. Make these repositories enabled by default (set `Override Enabled` for these repositories in the Activation Key configuration). Provide Activation Key for the build process by using argument `KEYNAME`.
+
+### Build the image
+
+After all prerequisites completed, ensure all required build arguments are in place:
+
+BASE_IMAGE - path to RHEL8/9 UBI image, for example `redhat.spectrocloud.dev/ubi9-init:9.4-6`
+
+KAIROS_FRAMEWORK_IMAGE - path to Kairos framework image, for example `quay.spectrocloud.dev/kairos/framework:v2.7.33`
+
+SATHOSTNAME - Red Hat Satellite hostname, for example `katello.spectrocloud.dev`
+
+ORGNAME - Organization name in Red Hat Satellite, for example `test-org`
+
+KEYNAME - Name of the Activation key with repositories attached, for example `rhel9-canvos-key`
+
+To build RHEL 8 Kairos Image, execute:
+```
+docker build -t <local-registry>/<image>:<image-tag> --build-arg BASE_IMAGE=<base image path> --build-arg KAIROS_FRAMEWORK_IMAGE='<Kairos Framework Path>' --build-arg SATHOSTNAME=<Satellite hostname>  --build-arg ORGNAME=<Satellite Org Name> --build-arg KEYNAME=<Activation key name> -f Dockerfile.rhel8.sat .
+```
+
+To build RHEL 9 Kairos Image, execute:
+```
+docker build -t <local-registry>/<image>:<image-tag> --build-arg BASE_IMAGE=<base image path> --build-arg KAIROS_FRAMEWORK_IMAGE='<Kairos Framework Path>' --build-arg SATHOSTNAME=<Satellite hostname>  --build-arg ORGNAME=<Satellite Org Name> --build-arg KEYNAME=<Activation key name> -f Dockerfile.rhel9.sat .
+```
+
+For example, to build RHEL9 image:
+```
+docker build -t localhost/palette-rhel9:latest --build-arg BASE_IMAGE=redhat.spectrocloud.dev/ubi9-init:9.4-6 --build-arg KAIROS_FRAMEWORK_IMAGE=quay.spectrocloud.dev/kairos/framework:v2.7.33 --build-arg SATHOSTNAME=katello.spectrocloud.dev  --build-arg ORGNAME=test-org --build-arg KEYNAME=rhel9-canvos-key -f Dockerfile.rhel9.sat .
+```
+
+For example, to build RHEL8 image:
+```
+docker build -t localhost/palette-rhel8:latest --build-arg BASE_IMAGE=redhat.spectrocloud.dev/ubi8/ubi-init:8.7-10 --build-arg KAIROS_FRAMEWORK_IMAGE=quay.spectrocloud.dev/kairos/framework:v2.7.33 --build-arg SATHOSTNAME=katello.spectrocloud.dev  --build-arg ORGNAME=test-org --build-arg KEYNAME=rhel8-canvos-key -f Dockerfile.rhel8.sat .
+```
+
+
+

--- a/rhel-core-images/README.md
+++ b/rhel-core-images/README.md
@@ -16,7 +16,7 @@ To build RHEL 9 Kairos Image, execute:
 docker build -t <local-registry>/<image>:<image-tag> --build-arg USERNAME=<RHSM username> --build-arg PASSWORD='<RHSM password>' -f Dockerfile.rhel9 .
 ```
 
-**In case of any errors during package installation steps - these errors might be cause by previous build attempts. Execute `docker build` command again by providing argument `--no-cache` to build the image from scratch**
+**In case of any errors during package installation steps - these errors might be caused by previous build attempts. Execute `docker build` command again by providing argument `--no-cache` to build the image from scratch**
 
 ## Build the image using Red Hat Satellite and mirrored repositories
 

--- a/rhel-core-images/overlay/rhel9/system/oem/33_tmp_mount.yaml
+++ b/rhel-core-images/overlay/rhel9/system/oem/33_tmp_mount.yaml
@@ -1,0 +1,10 @@
+name: " tmp layout setup"
+stages:
+  initramfs.after:
+    - name: mount tmp
+      commands:
+      - systemctl enable tmp.mount
+  fs.before:
+    - name: start tmp
+      commands:
+      - systemctl start tmp.mount


### PR DESCRIPTION
Added RHEL 9 Dockerfile based on CanvOS 4.4 RHEL 8 Dockerfile (with updated Kairos Framework).
Added RHEL 9 and RHEL 8 Dockerfiles to build images with Red Hat Satellite/mirrored repositories
README file updated