### PR TITLE
PE-4832: changing size to maxsize

### DIFF
--- a/overlay/files/etc/logrotate.d/stylus.conf
+++ b/overlay/files/etc/logrotate.d/stylus.conf
@@ -7,7 +7,7 @@
     dateext
     dateformat -%d-%m-%Y
     extension .log
-    size 100M
+    maxsize 100M
     create 600 root root
     # to avoid 'writable by group or others' error
     su root root


### PR DESCRIPTION
Setting a size limit using 'size' did not respect time periods like daily, hourly, or yearly.
Changing `size` to `maxsize` will fix this