### PR TITLE
Postgresql fixes

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -649,7 +649,10 @@ provider-image:
             curl -L https://github.com/k3s-io/kine/releases/download/v${KINE_VERSION}/kine-amd64 | install -m 755 /dev/stdin /opt/spectrocloud/bin/kine
 
         # Ensure psql works ootb for the postgres user
-        RUN su postgres -c 'echo "export PERL5LIB=/usr/share/perl/5.34:/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl/5.34" > ~/.bash_profile'
+        RUN su postgres -c 'echo "export PERL5LIB=/usr/share/perl/5.34:/etc/perl:/usr/lib/x86_64-linux-gnu/perl5/5.34:/usr/share/perl5:/usr/lib/x86_64-linux-gnu/perl/5.34:/usr/lib/x86_64-linux-gnu/perl-base" > ~/.bash_profile'
+
+        # Ensure psql waits for the network to be online
+        RUN sed -i 's/After=network.target/After=network-online.target/' /lib/systemd/system/postgresql@.service
     END
 
     SAVE IMAGE --push $IMAGE_PATH


### PR DESCRIPTION
* Adjust PERL5LIB path so `psql` works interactively
* Adjust `/lib/systemd/system/postgresql@.service` so postgresql waits for the network to be online, in order to prevent situations where it doesn't bind to the IP address on the NIC.