### PR TITLE
Support extra KEK/db keys

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -419,6 +419,8 @@ uki-byok:
     RUN apt-get update && apt-get install -y efitools curl
     COPY +download-sbctl/sbctl /usr/bin/sbctl
     COPY --if-exists secure-boot/exported-keys/ /exported-keys
+    COPY --if-exists secure-boot/extra-KEK-keys/ /usr/share/secureboot/keys/custom/KEK/
+    COPY --if-exists secure-boot/extra-db-keys/ /usr/share/secureboot/keys/custom/db/
     COPY secure-boot/private-keys/ secure-boot/public-keys /keys
     WORKDIR /keys
     RUN sbctl import-keys \
@@ -430,9 +432,9 @@ uki-byok:
         --db-cert /keys/db.pem
     RUN sbctl create-keys
     IF [ "$INCLUDE_MS_SECUREBOOT_KEYS" = "false" ]
-        RUN sbctl enroll-keys --export esl --yes-this-might-brick-my-machine
+        RUN sbctl enroll-keys --custom --export esl --yes-this-might-brick-my-machine
     ELSE
-        RUN sbctl enroll-keys --export esl --yes-this-might-brick-my-machine --microsoft
+        RUN sbctl enroll-keys --custom --export esl --yes-this-might-brick-my-machine --microsoft
     END
     RUN mkdir -p /output
     RUN cp PK.esl  /output/PK.esl  2>/dev/null

--- a/README.md
+++ b/README.md
@@ -270,6 +270,19 @@ secure-boot/
 |   |   PK.pem
 ```
 
+Optionally, you can add additional public keys to be added to the KEK and/or db database, by placing them in the following directories:
+```shell
+secure-boot/
+|   extra-KEK-keys <-- extra KEK keys to include, can be any filename, supports PEM and DER certificates
+|   |   key1.pem
+|   |   key2.pem
+|   |   ...
+|   extra-db-keys <-- extra db keys to include, can be any filename, supports PEM and DER certificates
+|   |   key1.pem
+|   |   key2.pem
+|   |   ...
+```
+
 3. Generate keys for Trusted Boot
 
 ```shell


### PR DESCRIPTION
This PR adds support to easily add additional certificates to the KEK and/or DB signature databases, by placing PEM or DER certificates in `secure-boot/extra-KEK-keys/` or `secure-boot/extra-db-keys/`.