### PR TITLE
chore: bump provider k3s to 4.5.0-alpha2 and kubeadm to 4.5.0-alpha3

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -21,8 +21,8 @@ ARG RKE2_FLAVOR_TAG=rke2r1
 ARG BASE_IMAGE_URL=quay.io/kairos
 ARG OSBUILDER_VERSION=v0.300.3
 ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:$OSBUILDER_VERSION
-ARG K3S_PROVIDER_VERSION=v4.5.0-alpha1
-ARG KUBEADM_PROVIDER_VERSION=v4.5.0-alpha2
+ARG K3S_PROVIDER_VERSION=v4.5.0-alpha2
+ARG KUBEADM_PROVIDER_VERSION=v4.5.0-alpha3
 ARG RKE2_PROVIDER_VERSION=v4.4.1
 
 # Variables used in the builds. Update for ADVANCED use cases only. Modify in .arg file or via CLI arguments.


### PR DESCRIPTION
Signed-off-by: Nianyu Shen <xiaoyu9964@gmail.com>