### PR TITLE
Fix 'DRBD_VERSION' format in .arg.template

### DIFF
--- a/.arg.template
+++ b/.arg.template
@@ -25,4 +25,4 @@ EDGE_CUSTOM_CONFIG=.edge-custom-config.yaml
 # INCLUDE_MS_SECUREBOOT_KEYS=true       # Adds Microsoft Secure Boot certificates; if you export existing keys from a device, you typically won't need this
 # AUTO_ENROLL_SECUREBOOT_KEYS=false     # Set to true to automatically enroll certificates on devices in Setup Mode, useful for flashing devices without user interaction
 
-# DRBD_VERSION="9.2.13"  # This variable is required for Piraeus pack for drbd module installtion.
+# DRBD_VERSION=9.2.13  # This variable is required for Piraeus pack for drbd module installtion.

--- a/.arg.template
+++ b/.arg.template
@@ -13,7 +13,7 @@ CLUSTERCONFIG=spc.tgz
 CIS_HARDENING=false
 EDGE_CUSTOM_CONFIG=.edge-custom-config.yaml
 
-ARG DRBD_VERSION="9.2.13"  # This variable is required for Piraeus pack for drbd module installtion.
+
 
 # If you have Ubuntu Pro, use the UBUNTU_PRO_KEY variable to activate it as part of the image build
 # UBUNTU_PRO_KEY=your-key
@@ -24,3 +24,5 @@ ARG DRBD_VERSION="9.2.13"  # This variable is required for Piraeus pack for drbd
 # UKI_BRING_YOUR_OWN_KEYS=false         # See sb-private-ca/howto.md for instructions on bringing your own certificates
 # INCLUDE_MS_SECUREBOOT_KEYS=true       # Adds Microsoft Secure Boot certificates; if you export existing keys from a device, you typically won't need this
 # AUTO_ENROLL_SECUREBOOT_KEYS=false     # Set to true to automatically enroll certificates on devices in Setup Mode, useful for flashing devices without user interaction
+
+# DRBD_VERSION="9.2.13"  # This variable is required for Piraeus pack for drbd module installtion.


### PR DESCRIPTION
Changing format of DRDB variable to be consistent with other .arg versions