### PR TITLE
PE-:8215: Fix Kairos-init version to v0.8.5 

### DIFF
--- a/rhel-core-images/Dockerfile.rhel8.sat
+++ b/rhel-core-images/Dockerfile.rhel8.sat
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-init:8.7-10
-ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:0.8.5
+ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.5
 
 FROM $KAIROS_INIT_IMAGE as kairos-init
 

--- a/rhel-core-images/Dockerfile.rhel9.sat
+++ b/rhel-core-images/Dockerfile.rhel9.sat
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=registry.access.redhat.com/ubi9-init:9.4-6
-ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:0.8.5
+ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.5
 
 FROM $KAIROS_INIT_IMAGE as kairos-init
 

--- a/rhel-stig/Dockerfile.rhel9
+++ b/rhel-stig/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
 FROM registry.access.redhat.com/ubi9-init:9.4-6
 
 ARG USERNAME

--- a/rhel-stig/Dockerfile.rhel9-fips
+++ b/rhel-stig/Dockerfile.rhel9-fips
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
 FROM registry.access.redhat.com/ubi9-init:9.4-6
 
 ARG USERNAME

--- a/ubuntu-fips/20.04/Dockerfile
+++ b/ubuntu-fips/20.04/Dockerfile
@@ -1,6 +1,6 @@
 
 # Kairos init image
-FROM quay.io/kairos/kairos-init:0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
 
 # Base ubuntu image (focal)
 FROM ubuntu:focal AS base

--- a/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
+++ b/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
 
 FROM ubuntu:22.04
 ARG VERSION=v4.0.3


### PR DESCRIPTION
For Ubuntu images and RHEL stig images