### PR TITLE
feat: add Kairos debug flags to installer grub cmdline when DEBUG enabled

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -363,6 +363,11 @@ build-iso:
         mv /overlay/boot/grub2/grub.cfg.tmp /overlay/boot/grub2/grub.cfg; \
     fi
 
+    # Append Kairos debug flags to installer kernel cmdline when DEBUG is enabled
+    RUN if [ "$DEBUG" = "true" ]; then \
+        sed -i '/rd.immucore.sysrootwait/s/$/ rd.immucore.debug console=tty0 rd.debug/' /overlay/boot/grub2/grub.cfg; \
+    fi
+
     # Add content files (split if > 3GB)
     COPY --if-exists content-*/*.zst /overlay/opt/spectrocloud/content/
     RUN if [ -n "$(ls /overlay/opt/spectrocloud/content/*.zst 2>/dev/null)" ]; then \


### PR DESCRIPTION
## Summary
- When `DEBUG=true`, append `rd.immucore.debug console=tty0 rd.debug` to the three installer menu entries in `overlay/files-iso/boot/grub2/grub.cfg` so boot-time logs from immucore and dracut surface on the console.
- Complements the existing build-time `--debug` verbosity that `DEBUG=true` already passes to the `build-iso` entrypoint.
- Flags sourced from the [Kairos troubleshooting guide](https://kairos.io/docs/reference/troubleshooting/). Scope limited to the non-UKI ISO installer; UKI cmdlines are measured into the TPM and cannot be patched post-build.

## Test plan
- [ ] `earthly +iso --DEBUG=false` — confirm grub.cfg kernel lines are unchanged.
- [ ] `earthly +iso --DEBUG=true` — confirm the three installer entries end with ` rd.immucore.debug console=tty0 rd.debug`.
- [ ] Boot the `DEBUG=true` ISO on a test node and verify extra immucore/dracut debug output appears on the console during install.