### PR TITLE
Fix missing iscsi_tcp module when UPDATE_KERNEL=true on Ubuntu HWE

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -726,7 +726,7 @@ base-image:
         ELSE
             SET APT_UPGRADE_FLAGS="-y --with-new-pkgs"
             RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-                apt-get install -y linux-image-generic-hwe-$OS_VERSION
+                apt-get install -y linux-image-generic-hwe-$OS_VERSION linux-modules-extra-hwe-$OS_VERSION
         END
 
         # https://www.reddit.com/r/Ubuntu/comments/1bd46t3/i_did_an_aptget_updateupgrade_but_the_kernel/
@@ -766,6 +766,13 @@ base-image:
                 rm -rf /var/lib/apt/lists/*
             RUN kernel=$(ls /boot/vmlinuz-* | tail -n1) && \
            	ln -sf "${kernel#/boot/}" /boot/vmlinuz
+            # Ensure iscsi_tcp and related modules are included in the initrd when UPDATE_KERNEL is used.
+            # iscsi_tcp lives in linux-modules-extra (not linux-image) and is not auto-included by
+            # mkinitramfs, which is the fallback when dracut fails. Without this, Longhorn and other
+            # iSCSI-backed storage CSI drivers fail to attach volumes on the HWE kernel.
+            RUN for mod in iscsi_tcp libiscsi libiscsi_tcp scsi_transport_iscsi; do \
+                    grep -qxF "$mod" /etc/initramfs-tools/modules 2>/dev/null || echo "$mod" >> /etc/initramfs-tools/modules; \
+                done
             # Skip dracut when FIPS is enabled - the Dockerfile will include custom dracut modules.fips
             IF [ "$FIPS_ENABLED" = "false" ]
                 RUN kernel=$(printf '%s\n' /lib/modules/* | xargs -n1 basename | sort -V | tail -1) && \

--- a/Earthfile
+++ b/Earthfile
@@ -726,7 +726,9 @@ base-image:
         ELSE
             SET APT_UPGRADE_FLAGS="-y --with-new-pkgs"
             RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-                apt-get install -y linux-image-generic-hwe-$OS_VERSION linux-modules-extra-hwe-$OS_VERSION
+                apt-get install -y linux-image-generic-hwe-$OS_VERSION && \
+                kernel=$(ls /lib/modules | sort -V | tail -1) && \
+                apt-get install -y linux-modules-extra-${kernel}
         END
 
         # https://www.reddit.com/r/Ubuntu/comments/1bd46t3/i_did_an_aptget_updateupgrade_but_the_kernel/


### PR DESCRIPTION
## Problem

When `UPDATE_KERNEL=true`, `linux-image-generic-hwe-<OS_VERSION>` is installed but `linux-modules-extra-hwe-<OS_VERSION>` is not. On Ubuntu, `iscsi_tcp.ko` ships in the extras package — not in the base kernel image — so it is completely absent from `/lib/modules/<hwe-kernel>/`. At runtime, Longhorn and other iSCSI-backed CSI drivers fail with:

```
iscsi required but kernel/initrd does not support iscsi
```

This was observed in CI run [spectrocloud/teams#3188](https://github.com/spectrocloud/teams/actions/runs/25809938792) for the `ubuntu-22.04 / kubeadm-fips / UPDATE_KERNEL=true` build, where the HWE kernel `6.8.0-111-generic` became the boot kernel but lacked `iscsi_tcp`.

A secondary issue is that dracut fails during the build (`ERROR: installing 'libnvdimm'`) and mkinitramfs is used as a fallback — which does not auto-include `iscsi_tcp` in the initrd without explicit configuration.

## Changes

- **Install `linux-modules-extra-hwe-$OS_VERSION`** alongside the HWE kernel so `iscsi_tcp.ko` is present in the module tree.
- **Add iSCSI modules to `/etc/initramfs-tools/modules`** (`iscsi_tcp`, `libiscsi`, `libiscsi_tcp`, `scsi_transport_iscsi`) so mkinitramfs includes them in the initrd.

## Test plan

- [ ] Build with `UPDATE_KERNEL=true`, `OS_DISTRIBUTION=ubuntu`, `OS_VERSION=22.04`, `K8S_DISTRIBUTION=kubeadm-fips`
- [ ] Verify `modinfo iscsi_tcp` succeeds on the booted HWE kernel
- [ ] Verify Longhorn / iSCSI storage attaches without errors
- [ ] Verify non-UPDATE_KERNEL builds are unaffected (change is inside `ELSE` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)