### PR TITLE
PE-8711: switch internal Earthfile base from Alpine to Ubuntu

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -7,13 +7,11 @@ ARG SPECTRO_PUB_REPO=us-docker.pkg.dev/palette-images
 ARG BUILDER_3RDPARTY_VERSION=4.8
 ARG SPECTRO_THIRD_PARTY_IMAGE=us-docker.pkg.dev/palette-images/third-party/spectro-third-party:$BUILDER_3RDPARTY_VERSION
 ARG ALPINE_TAG=3.20
-ARG ALPINE_IMG=$SPECTRO_PUB_REPO/edge/canvos/alpine:$ALPINE_TAG
-FROM $ALPINE_IMG
+FROM +ubuntu
 
 ARG FIPS_ENABLED=false
 IF [ "$FIPS_ENABLED" = "true" ] && [ "$SPECTRO_PUB_REPO" = "us-docker.pkg.dev/palette-images" ]
     LET SPECTRO_PUB_REPO=us-docker.pkg.dev/palette-images-fips
-    LET ALPINE_IMG=$SPECTRO_PUB_REPO/edge/canvos/alpine:$ALPINE_TAG
 END
 
 ARG SPECTRO_LUET_REPO=us-docker.pkg.dev/palette-images/edge
@@ -171,7 +169,8 @@ build-all-images:
     END
 
 build-provider-images:
-    FROM $ALPINE_IMG
+    FROM +ubuntu
+    RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
 
     IF [ !-n "$K8S_DISTRIBUTION"]
         RUN echo "K8S_DISTRIBUTION is not set. Please set K8S_DISTRIBUTION to kubeadm, kubeadm-fips, k3s, nodeadm, rke2 or canonical." && exit 1
@@ -198,7 +197,7 @@ build-provider-images:
 build-provider-images-fips:
    BUILD +build-provider-images
 
-BASE_ALPINE:
+BASE_UBUNTU:
     COMMAND
     COPY --if-exists certs/ /etc/ssl/certs/
     RUN update-ca-certificates
@@ -248,8 +247,8 @@ kairos-agent:
     SAVE ARTIFACT /usr/bin/kairos-agent /kairos-agent
 
 install-k8s:
-    FROM --platform=linux/${ARCH} $ALPINE_IMG
-    DO +BASE_ALPINE
+    FROM --platform=linux/${ARCH} +ubuntu
+    DO +BASE_UBUNTU
     COPY (+third-party/luet --binary=luet) /usr/bin/luet
 
     IF [ "$K8S_DISTRIBUTION" = "kubeadm" ] || [ "$K8S_DISTRIBUTION" = "kubeadm-fips" ] || [ "$K8S_DISTRIBUTION" = "nodeadm" ] || [ "$K8S_DISTRIBUTION" = "canonical" ]
@@ -451,8 +450,9 @@ uki-genkey:
     END
 
 download-sbctl:
-    FROM $ALPINE_IMG
-    DO +BASE_ALPINE
+    FROM +ubuntu
+    DO +BASE_UBUNTU
+    RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
     RUN curl -Ls https://github.com/Foxboron/sbctl/releases/download/0.13/sbctl-0.13-linux-amd64.tar.gz | tar -xvzf - && mv sbctl/sbctl /usr/bin/sbctl
     SAVE ARTIFACT /usr/bin/sbctl
 
@@ -1267,7 +1267,8 @@ download-third-party:
     SAVE ARTIFACT /binaries/${binary}/latest/$BIN_TYPE/$TARGETARCH/${binary}.version ${binary}.version
 
 third-party:
-    FROM $ALPINE_IMG
+    FROM +ubuntu
+    RUN apt-get update && apt-get install -y --no-install-recommends upx-ucl && rm -rf /var/lib/apt/lists/*
     ARG binary
     WORKDIR /WORKDIR
 


### PR DESCRIPTION
## Summary

Switches the internal Earthfile targets that previously consumed `$ALPINE_IMG` to use the existing `+ubuntu` target. The published `+alpine` / `+alpine-all` targets, `earthly/dind:alpine-*`, and `golang:*-alpine` are intentionally left unchanged — they are external/upstream.

## Changes

**Targets switched to `+ubuntu`** (which already handles the FIPS variant via `$SPECTRO_PUB_REPO/third-party/ubuntu-fips:22.04`):
- File-level base (`FROM` at top of Earthfile)
- `build-provider-images`
- `install-k8s`
- `download-sbctl`
- `third-party`

**UDC renamed**: `BASE_ALPINE` → `BASE_UBUNTU` (definition + 2 callers). Body unchanged — `update-ca-certificates` is portable.

**Package installs added** (Ubuntu base does not include what Alpine had baked in):
- `build-provider-images`: `jq` (used to parse `k8s_version.json`)
- `download-sbctl`: `curl ca-certificates` (used to fetch sbctl tarball)
- `third-party`: `upx-ucl` (used by the `UPX` UDC)

**Out of scope** (deliberately not touched):
- `+alpine` / `+alpine-all` — still publishes `gcr.io/spectro-dev-public/canvos/alpine:$ALPINE_TAG`; external consumers may depend on it.
- `earthly/dind:alpine-3.19-docker-25.0.5-r0` (cloud-image, aws-cloud-image) — upstream Earthly DinD runtime.
- `$SPECTRO_PUB_REPO/third-party/golang:${GOLANG_VERSION}-alpine` (go-deps) — upstream Go build image.

## Validation

- `earthly ls` parses the Earthfile cleanly; all 40 targets resolve.
- Static review only — full builds still need to be exercised by CI/maintainer.

## Test plan

- [ ] CI green for `+build-provider-images` across all k8s distributions.
- [ ] CI green for `+install-k8s`, `+download-sbctl`, `+third-party`.
- [ ] FIPS path validated (`FIPS_ENABLED=true`) — `+ubuntu` picks the `ubuntu-fips:22.04` variant.
- [ ] Confirm published `gcr.io/spectro-dev-public/canvos/alpine:$ALPINE_TAG` is still produced by `+alpine-all`.