### PR TITLE
feat: enable cgroup v2 by default for all installers (PE-8520)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,6 @@ COPY overlay/files/etc/spectrocloud/custom-hardware-specs-lookup.json /etc/spect
 # ENTRYPOINT /entry.sh
 
 # Enable cgroup v2 (unified hierarchy) — required for Kubernetes >= 1.31 (deprecated in 1.31, hard-fail in 1.35)
-RUN if ! grep -q "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
+RUN if ! grep -Fq "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
         sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,5 +96,7 @@ COPY overlay/files/etc/spectrocloud/custom-hardware-specs-lookup.json /etc/spect
 # ENV LB_HOW compile
 # ENTRYPOINT /entry.sh
 
-# to set cgroupv2 as default
-#RUN sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg
+# Enable cgroup v2 (unified hierarchy) — required for Kubernetes >= 1.31 (deprecated in 1.31, hard-fail in 1.35)
+RUN if ! grep -q "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
+        sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg; \
+    fi

--- a/Earthfile
+++ b/Earthfile
@@ -838,7 +838,7 @@ base-image:
     END
 
     # Enable cgroup v2 (unified hierarchy) — required for Kubernetes >= 1.31 (deprecated in 1.31, hard-fail in 1.35)
-    RUN if ! grep -q "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
+    RUN if ! grep -Fq "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
             sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg; \
         fi
 

--- a/Earthfile
+++ b/Earthfile
@@ -837,6 +837,11 @@ base-image:
             if grep "selinux=1" /etc/cos/bootargs.cfg > /dev/null; then sed -i 's/selinux=1/selinux=0/g' /etc/cos/bootargs.cfg; fi
     END
 
+    # Enable cgroup v2 (unified hierarchy) — required for Kubernetes >= 1.31 (deprecated in 1.31, hard-fail in 1.35)
+    RUN if ! grep -q "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
+            sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg; \
+        fi
+
 KAIROS_RELEASE:
     COMMAND
     ARG OS_VERSION

--- a/overlay/files-iso/boot/grub2/grub.cfg
+++ b/overlay/files-iso/boot/grub2/grub.cfg
@@ -13,21 +13,21 @@ if [ -f ${font} ];then
 fi
 menuentry "Palette eXtended Kubernetes Edge Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette eXtended Kubernetes Edge Installer (manual)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette Edge Interactive Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 interactive-install
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 interactive-install
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }


### PR DESCRIPTION
## Summary

Kubernetes 1.35 enforces a hard kubelet validation that refuses to start on cgroup v1 hosts. This caused edge clusters running k3s v1.35.2+k3s1 to enter a permanent crash-restart loop on upgrade 

**Root cause:** OS images (e.g. SLE Micro 5.4 / Kairos v4.0.3) boot in cgroup v1 hybrid mode because `systemd.unified_cgroup_hierarchy=1` was not set in the kernel cmdline.

**Fix:** Add `systemd.unified_cgroup_hierarchy=1` unconditionally to all installer paths:

- **`Earthfile`** — patches `/etc/cos/bootargs.cfg` during image build, so all installed OS images boot with cgroup v2. Covers all `grubmenu.cfg` entries (`kairos.reset`, `stylus.registration`) which inherit from `${extra_cmdline}`.
- **`overlay/files-iso/boot/grub2/grub.cfg`** — adds the parameter to all 3 ISO installer menu entries (default, manual, interactive), so the live installer environment also runs under cgroup v2.
- **`Dockerfile`** — activates the previously-commented cgroup v2 sed line for custom image builds using the Dockerfile path directly.

**Backward compatibility:** cgroup v2 went GA in Kubernetes 1.25. This change is safe for all k8s versions supported in CanvOS (≥ 1.28). Kubernetes 1.31 deprecated cgroup v1; 1.35 makes it a hard failure.

## Changed Files

| File | Change |
|---|---|
| `Earthfile` | Unconditionally inject `systemd.unified_cgroup_hierarchy=1` into `bootargs.cfg` post-build |
| `overlay/files-iso/boot/grub2/grub.cfg` | Add kernel param to all 3 installer grub menu entries |
| `Dockerfile` | Activate previously-commented cgroup v2 line (idempotent guard added) |

## Test plan
- [x] Build a provider image and verify `/proc/cmdline` on the installed OS contains `systemd.unified_cgroup_hierarchy=1`
- [x] Verify `stat -fc %T /sys/fs/cgroup` returns `cgroup2fs` (not `tmpfs`) after install
- [x] Boot the installer ISO and confirm the live environment uses cgroup v2
- [x] Deploy k3s v1.35.2 on a freshly built image — kubelet should start without cgroup v1 errors
- [ ] Verify existing k8s 1.28/1.29/1.30 clusters still come up correctly (cgroup v2 is backward-compatible)

## References
- [KEP-4569](https://github.com/kubernetes/enhancements/issues/4569) — Kubernetes cgroup v1 deprecation
- Existing README.md documentation on cgroup v2 (lines 733–751)