### PR TITLE
Bake fips=1 into bootargs.cfg for FIPS provider images

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -848,6 +848,12 @@ base-image:
         RUN if ! grep -Fq "systemd.unified_cgroup_hierarchy=1" /etc/cos/bootargs.cfg; then \
                 sed -i 's|\(set baseCmd="[^"]*\)"|\1 systemd.unified_cgroup_hierarchy=1"|' /etc/cos/bootargs.cfg; \
             fi
+
+        IF [ "$FIPS_ENABLED" = "true" ]
+            RUN if ! grep -Fq "fips=1" /etc/cos/bootargs.cfg; then \
+                    sed -i 's|\(set baseCmd="[^"]*\)"|\1 fips=1"|' /etc/cos/bootargs.cfg; \
+                fi
+        END
     END
 
 KAIROS_RELEASE:


### PR DESCRIPTION
## Summary
- When a non-FIPS slim ISO bootstraps a node and a FIPS provider image is flashed during cluster creation, there is no `user-data` cloud-config step to inject `grub_options.extra_cmdline: "fips=1"`.
- This adds `fips=1` directly into `/etc/cos/bootargs.cfg` at build time when `FIPS_ENABLED=true`, ensuring the kernel boots in FIPS mode after the flash — no operator intervention needed.
- Follows the exact same pattern already used for `systemd.unified_cgroup_hierarchy=1` and `selinux=0`. Non-FIPS builds are unaffected.

## Test plan
- [ ] Build a FIPS provider image (`FIPS_ENABLED=true`) and verify `/etc/cos/bootargs.cfg` contains `fips=1` in `baseCmd`
- [ ] Build a non-FIPS provider image and verify `fips=1` is NOT present in `bootargs.cfg`
- [ ] Flash a FIPS provider image onto a node bootstrapped from a non-FIPS slim ISO, confirm `/proc/sys/crypto/fips_enabled` is `1` after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)