### PR TITLE
PE-9025: update kairos-init to v0.8.12

### DIFF
--- a/rhel-core-images/Dockerfile.rhel8
+++ b/rhel-core-images/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 FROM registry.access.redhat.com/ubi8/ubi-init:8.7-10
 
 ARG USERNAME

--- a/rhel-core-images/Dockerfile.rhel8.sat
+++ b/rhel-core-images/Dockerfile.rhel8.sat
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-init:8.7-10
-ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.5
+ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.12
 
 FROM $KAIROS_INIT_IMAGE as kairos-init
 

--- a/rhel-core-images/Dockerfile.rhel9
+++ b/rhel-core-images/Dockerfile.rhel9
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 FROM registry.access.redhat.com/ubi9-init:9.4-6
 
 ARG USERNAME

--- a/rhel-core-images/Dockerfile.rhel9.sat
+++ b/rhel-core-images/Dockerfile.rhel9.sat
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=registry.access.redhat.com/ubi9-init:9.4-6
-ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.5
+ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:v0.8.12
 
 FROM $KAIROS_INIT_IMAGE as kairos-init
 

--- a/rhel-fips/Dockerfile.rhel8
+++ b/rhel-fips/Dockerfile.rhel8
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Kairos init image
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 FROM registry.access.redhat.com/ubi8/ubi-init:8.7-10 AS base
 
 ARG USERNAME

--- a/rhel-fips/Dockerfile.rhel9
+++ b/rhel-fips/Dockerfile.rhel9
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Kairos init image
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 
 FROM registry.access.redhat.com/ubi9-init:9.4-6 AS base
 

--- a/rhel-stig/Dockerfile.rhel9
+++ b/rhel-stig/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 FROM registry.access.redhat.com/ubi9-init:9.4-6
 
 ARG USERNAME

--- a/rhel-stig/Dockerfile.rhel9-fips
+++ b/rhel-stig/Dockerfile.rhel9-fips
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 FROM registry.access.redhat.com/ubi9-init:9.4-6
 
 ARG USERNAME

--- a/slem/Dockerfile
+++ b/slem/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 
 FROM registry.suse.com/suse/sle-micro-rancher/5.4:latest
 

--- a/ubuntu-fips/20.04/Dockerfile
+++ b/ubuntu-fips/20.04/Dockerfile
@@ -1,6 +1,6 @@
 
 # Kairos init image
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 
 # Base ubuntu image (focal)
 FROM ubuntu:focal AS base

--- a/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
+++ b/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 
 FROM ubuntu:22.04
 ARG VERSION=v4.0.3

--- a/ubuntu-fips/24.04/Dockerfile.ubuntu24.04-fips
+++ b/ubuntu-fips/24.04/Dockerfile.ubuntu24.04-fips
@@ -1,4 +1,4 @@
-FROM quay.io/kairos/kairos-init:v0.8.5 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.8.12 AS kairos-init
 
 FROM ubuntu:24.04
 ARG VERSION=v4.0.3


### PR DESCRIPTION
## Summary

Bumps the `kairos-init` image from `v0.8.11` to `v0.8.12` across all Dockerfiles.

This supersedes the earlier `chore/bump-kairos-init-0.8.11` branch.

## Changes
Updated `quay.io/kairos/kairos-init` reference to `v0.8.12` in 12 Dockerfiles:
- `rhel-core-images/Dockerfile.rhel8`, `Dockerfile.rhel8.sat`, `Dockerfile.rhel9`, `Dockerfile.rhel9.sat`
- `rhel-fips/Dockerfile.rhel8`, `Dockerfile.rhel9`
- `rhel-stig/Dockerfile.rhel9`, `Dockerfile.rhel9-fips`
- `slem/Dockerfile`
- `ubuntu-fips/20.04/Dockerfile`, `ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips`, `ubuntu-fips/24.04/Dockerfile.ubuntu24.04-fips`

## Test plan
- [ ] CI image builds succeed with the new kairos-init version