### PR TITLE
PE-8824: fix(two-node): bump bundled kine to v0.15.0

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -72,7 +72,7 @@ ARG ETCD_VERSION="v3.5.13"
 
 # Two node variables
 ARG TWO_NODE=false
-ARG KINE_VERSION=0.11.4
+ARG KINE_VERSION=0.15.0
 
 # MAAS Variables
 ARG IS_MAAS=false


### PR DESCRIPTION
## Summary
  For 2-node edge clusters, CanvOS bundles the kine binary (`Earthfile` `KINE_VERSION`). The pinned **v0.11.4** defaults `--watch-progress-notify-interval` to **10 minutes**; under write load this lets the kube-apiserver watch cache for unmutated resources (`cdiconfigs`, `virtualmachines`, …) fall far behind the global revision → `ResourceVersionTooLarge` → LIST→watch
  storm → the **KubeVirt VNC console disconnects every ~30–60s** (PE-8824 / SUS-1721).

  This bumps the bundled kine to **v0.15.0**, which:
  - defaults `--watch-progress-notify-interval` to **5s** (kept upstream since v0.12.0), keeping the watch cache fresh, and
  - picks up the related *compact-revision* and *cache-consistency* fixes.


  ## Change
  `Earthfile`
  - `ARG KINE_VERSION=0.11.4` → `ARG KINE_VERSION=0.15.0`