### PR TITLE
chore: bump pe version to v4.9.20-rc.2

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -20,7 +20,7 @@ ARG SPECTRO_LUET_REPO=us-docker.pkg.dev/palette-images/edge
 ARG KAIROS_BASE_IMAGE_URL=$SPECTRO_PUB_REPO/edge
 
 # Spectro Cloud and Kairos tags.
-ARG PE_VERSION=v4.9.20-rc.1
+ARG PE_VERSION=v4.9.20-rc.2
 ARG KAIROS_VERSION=v4.0.3
 ARG K3S_FLAVOR_TAG=k3s1
 ARG RKE2_FLAVOR_TAG=rke2r1


### PR DESCRIPTION
Automated PE version bump from [stylus](https://github.com/spectrocloud/stylus) release `v4.9.20-rc.2`.

Target branch: `rc-4.9`