### PR TITLE
feat: support installer boot from USB media on Renesas xHCI hardware

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -770,6 +770,12 @@ base-image:
         COPY cloudconfigs/80_stylus_maas.yaml /system/oem/80_stylus_maas.yaml
     END
 
+    # Ensure the Renesas xHCI (USB 3.0) host controller driver is bundled into the
+    # initramfs so installation from USB media works on hardware using that chipset.
+    # Must run before the distro dracut regeneration below so the driver is included.
+    RUN mkdir -p /etc/dracut.conf.d && \
+        printf '%s\n' 'hostonly="no"' 'add_drivers+=" xhci_pci_renesas "' 'force_drivers+=" xhci_pci_renesas "' > /etc/dracut.conf.d/99-usb-media.conf
+
     # OS == Ubuntu
     IF [ "$OS_DISTRIBUTION" = "ubuntu" ] &&  [ "$ARCH" = "amd64" ]
         IF [ ! -z "$UBUNTU_PRO_KEY" ]

--- a/overlay/files-iso/boot/grub2/grub.cfg
+++ b/overlay/files-iso/boot/grub2/grub.cfg
@@ -13,21 +13,21 @@ if [ -f ${font} ];then
 fi
 menuentry "Palette eXtended Kubernetes Edge Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 pci=realloc=off
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette eXtended Kubernetes Edge Installer (manual)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 pci=realloc=off
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette Edge Interactive Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 interactive-install
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 pci=realloc=off interactive-install
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/ubuntu-fips/20.04/99-usb-media.conf
+++ b/ubuntu-fips/20.04/99-usb-media.conf
@@ -1,0 +1,3 @@
+hostonly="no"
+add_drivers+=" xhci_pci_renesas "
+force_drivers+=" xhci_pci_renesas "

--- a/ubuntu-fips/20.04/Dockerfile
+++ b/ubuntu-fips/20.04/Dockerfile
@@ -112,6 +112,11 @@ RUN cd /usr/lib/dracut/modules.d/95iscsi && patch < /dracut-broken-iscsi-ubuntu-
 
 COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
 
+# Bundle the Renesas xHCI (USB 3.0) host controller driver into the initramfs so
+# installation from USB media works on hardware using that chipset. Consumed by the
+# `kairos-init -s init` dracut run below (the Earthfile skips dracut for FIPS builds).
+COPY 99-usb-media.conf /etc/dracut.conf.d/99-usb-media.conf
+
 # Copy the custom dracut modules.fips that includes 2 missing modules
 COPY modules.fips /tmp/modules.fips
 RUN kernel=$(ls /lib/modules | grep fips | head -n1) && mv /tmp/modules.fips /lib/modules/${kernel}/modules.fips

--- a/ubuntu-fips/22.04/99-usb-media.conf
+++ b/ubuntu-fips/22.04/99-usb-media.conf
@@ -1,0 +1,3 @@
+hostonly="no"
+add_drivers+=" xhci_pci_renesas "
+force_drivers+=" xhci_pci_renesas "

--- a/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
+++ b/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
@@ -32,6 +32,11 @@ RUN --mount=type=secret,id=pro-attach-config \
 
 COPY 22.04/dracut.conf /etc/dracut.conf.d/kairos-fips.conf
 
+# Bundle the Renesas xHCI (USB 3.0) host controller driver into the initramfs so
+# installation from USB media works on hardware using that chipset. Consumed by the
+# `kairos-init -s init` dracut run below (the Earthfile skips dracut for FIPS builds).
+COPY 22.04/99-usb-media.conf /etc/dracut.conf.d/99-usb-media.conf
+
 # Copy the custom dracut modules.fips that includes 2 missing modules
 COPY 22.04/modules.fips /tmp/modules.fips
 RUN kernel=$(ls /lib/modules | head -n1) && mv /tmp/modules.fips /lib/modules/${kernel}/modules.fips

--- a/ubuntu-fips/24.04/99-usb-media.conf
+++ b/ubuntu-fips/24.04/99-usb-media.conf
@@ -1,0 +1,3 @@
+hostonly="no"
+add_drivers+=" xhci_pci_renesas "
+force_drivers+=" xhci_pci_renesas "

--- a/ubuntu-fips/24.04/Dockerfile.ubuntu24.04-fips
+++ b/ubuntu-fips/24.04/Dockerfile.ubuntu24.04-fips
@@ -41,6 +41,11 @@ RUN --mount=type=secret,id=pro-attach-config \
 COPY 24.04/modules.fips /tmp/modules.fips
 RUN kernel=$(ls /lib/modules | head -n1) && mv /tmp/modules.fips /lib/modules/${kernel}/modules.fips
 
+# Bundle the Renesas xHCI (USB 3.0) host controller driver into the initramfs so
+# installation from USB media works on hardware using that chipset. Consumed by the
+# `kairos-init -s init` dracut run below (the Earthfile skips dracut for FIPS builds).
+COPY 24.04/99-usb-media.conf /etc/dracut.conf.d/99-usb-media.conf
+
 COPY 24.04/fix.sh /tmp/fix.sh
 COPY stig-remediate.sh /tmp/stig-remediate.sh
 COPY restore-ubuntu-default-banners.sh /tmp/restore-ubuntu-default-banners.sh


### PR DESCRIPTION
## Summary

Same USB-media boot enablement as #686, but targeted at the **`vipsharm-GPU`** branch so the GPU work carries the Renesas xHCI (USB 3.0) support.

Enables the Palette Edge installer to boot and install from USB media on hardware that uses a Renesas xHCI host controller.

### Non-FIPS path
- **`Earthfile`** — In `base-image`, write `/etc/dracut.conf.d/99-usb-media.conf` (`hostonly="no"`, `add_drivers`/`force_drivers` += `xhci_pci_renesas`) **before** the distro `dracut -f` regeneration so the driver is bundled into the generated initramfs.
- **`overlay/files-iso/boot/grub2/grub.cfg`** — Add `pci=realloc=off` to the installer menu entries.

### FIPS path
The Earthfile skips dracut for FIPS builds, so the driver config is added in the `ubuntu-fips` Dockerfiles where `kairos-init -s init --fips` regenerates the initramfs:
- Add `ubuntu-fips/{20.04,22.04,24.04}/99-usb-media.conf` and `COPY` it into `/etc/dracut.conf.d/` before the init step.

## Notes

- Base branch is `vipsharm-GPU` (not `main`). The equivalent change against `main` is #686.
- Uses `printf` / static `.conf` instead of heredoc — Earthly's `RUN` lexer does not support shell heredocs. Verified with `earthly ls`.

## Testing

- `earthly ls ./` parses the Earthfile without errors on this branch.