### PR TITLE
feat(pam): bake libpam-pwquality into Ubuntu base image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -786,7 +786,7 @@ base-image:
         END
 
         RUN apt-get update && \
-            DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends kbd zstd vim iputils-ping bridge-utils curl tcpdump ethtool rsyslog logrotate -y
+            DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends kbd zstd vim iputils-ping bridge-utils curl tcpdump ethtool rsyslog logrotate libpam-pwquality -y
 
         LET APT_UPGRADE_FLAGS="-y"
         IF [ "$UPDATE_KERNEL" = "false" ]


### PR DESCRIPTION
## Problem

Downstream appliance work (spectrocloud/launchpad-ai#314) needs a password-complexity policy on the built ISO. The natural PAM primitive for that on Debian/Ubuntu is `pam_pwquality.so`, but on Ubuntu 24.04 as it ships from this base:

- \`libpam-pwquality\` is **not** installed
- No cached \`.deb\` is present in \`/var/cache/apt/archives\`
- The appliance runs in airgap (`stylus.installationMode: airgap`), so first-boot `apt install` isn't an option

The alternative primitive — `pam_exec.so` + a shell helper — also doesn't work here: the shipped \`libpam-modules 1.4.0-11ubuntu2.6\` rejects \`expose_authtok\` for the \`password\` PAM type (support was added in Linux-PAM 1.5.x, not backported by Ubuntu). Verified on the running appliance:

\`\`\`
pam_exec(chpasswd:chauthtok): expose_authtok not supported for type password
\`\`\`

So the only clean path is baking \`libpam-pwquality\` into the OS image itself.

## Change

Add \`libpam-pwquality\` to the existing Ubuntu apt install line in the Earthfile — alongside \`kbd zstd vim iputils-ping bridge-utils curl tcpdump ethtool rsyslog logrotate\`. Single-package addition; brings in `libpwquality1` as a transitive dep.

## Impact

- Base image size grows by ~200 KB (`libpam-pwquality` ~30KB + `libpwquality1` ~110KB + dict).
- No PAM behavior change on its own — installing the package alone does not modify \`/etc/pam.d/common-password\`. Downstream user-data (spectrocloud/launchpad-ai#314) opts in via a \`pam-configs\` profile + \`pam-auth-update --package\`.
- No API/behavior change for existing appliances that don't use it.

## Test plan

- [ ] Build the AI Launchpad slim ISO from this branch, install on a test node.
- [ ] Verify \`dpkg -l libpam-pwquality\` returns installed, and \`/usr/lib/x86_64-linux-gnu/security/pam_pwquality.so\` exists.
- [ ] Merge spectrocloud/launchpad-ai#314 (or its follow-up switching to pwquality), install with both branches, and verify \`chpasswd\` rejects weak passwords and accepts compliant ones.

## Follow-ups

- spectrocloud/launchpad-ai#314 will be updated to use `pam_pwquality` (via `pam-configs`) instead of the pam_exec + shell approach that motivated this PR.
- Once verified on `vipsharm-GPU`, consider forwarding to the shared CanvOS branches used by other appliances so they can adopt a similar policy if desired.