### PR TITLE
fix: copy /system/providers/ from stylus image to support stylus v4.10.x on kubeadm nodes

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -643,6 +643,11 @@ provider-image:
     COPY +stylus-image/oem/stylus_config.yaml /etc/kairos/branding/stylus_config.yaml
     COPY +stylus-image/etc/elemental/config.yaml /etc/elemental/config.yaml
     COPY --if-exists "$EDGE_CUSTOM_CONFIG" /oem/.edge_custom_config.yaml
+    # stylus v4.10.x ships agent-provider-kubeadm alongside agent-provider-stylus in
+    # /system/providers/. Without this copy the runtime upgrade rsync tries to write
+    # agent-provider-kubeadm to /system/providers/ which is read-only at runtime,
+    # causing cluster creation to hang at "Upgrading provider image" on kubeadm nodes.
+    COPY --if-exists +stylus-image/system/providers/ /system/providers/
 
     IF [ "$IS_UKI" = "true" ]
         COPY +internal-slink/slink /usr/bin/slink


### PR DESCRIPTION
## Problem

When building AI Launchpad ISO with stylus `v4.10.x` (dev channel), cluster creation hangs indefinitely at **Upgrading provider image** with this error repeating every ~5s:

```
rsync: [receiver] mkstemp "/system/providers/.agent-provider-kubeadm.npHOIN" failed: Read-only file system (30)
failed to upgrade provider: exit status 23; failed to apply os upgrade
```

**Root cause:** stylus `v4.10.x` ships `agent-provider-kubeadm` in `/system/providers/` of the stylus-framework image and expects it to be present there at cluster creation time. The current Earthfile copies specific files from the stylus image (branding, config, etc.) but not `/system/providers/`. At runtime, stylus tries to write `agent-provider-kubeadm` to `/system/providers/` via content rsync — but that partition is read-only.

**Confirmed:** 
- RC ISO (stylus `v4.9.34`): works — `agent-provider-kubeadm` not required
- Dev ISO (stylus `v4.10.0-260805`): broken — stuck at provider upgrade

## Fix

Add one line to copy `/system/providers/` from the stylus framework image into the ISO. The `--if-exists` flag makes this backward-compatible: on stylus `v4.9.x` this is a no-op since only `agent-provider-stylus` is there (already placed by the kairos-provider-image copy).

## Testing

Trigger `On-Demand Slim ISO Build` with `channel=dev`, `data_ref=main`, flash on a GPU node, confirm cluster creation completes past **Upgrading provider image**.