### PR TITLE
AIL-418: feat(iso): port AuroraBoot v0.26.2 switch + overlay-inject workaround to PE-8787

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -31,9 +31,12 @@ ARG RKE2_FLAVOR_TAG=rke2r1
 ARG BASE_IMAGE_URL=quay.io/kairos
 ARG OSBUILDER_VERSION=v0.400.3
 ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:$OSBUILDER_VERSION
-# v0.18.0 is the minimum usable version. v0.16.0 and v0.17.0 do not work for the Hadron 
-
-ARG AURORABOOT_VERSION=v0.21.2
+# v0.18.0 is the minimum usable version. v0.16.0 and v0.17.0 do not work for the Hadron.
+# v0.26.2 also fixes the UEFI-only ISO boot path: xorriso appended_part_as=gpt for a
+# hybrid MBR+GPT layout (needed by VMware ESXi, OVMF/QEMU, some SuperMicro BMCs),
+# and the CD-variant signed GRUB binary (gcdx64.efi.signed) via kairos-sdk v0.25.2.
+# Kairos upstream: kairos-io/AuroraBoot#713, kairos-io/kairos-sdk#0.25.2.
+ARG AURORABOOT_VERSION=v0.26.2
 ARG AURORABOOT_IMAGE=quay.io/kairos/auroraboot:$AURORABOOT_VERSION
 ARG K3S_PROVIDER_VERSION=v4.10.0
 ARG KUBEADM_PROVIDER_VERSION=v4.10.0
@@ -385,7 +388,11 @@ install-k8s:
     SAVE ARTIFACT --keep-ts /output/ .
 
 build-uki-iso:
-    FROM --platform=linux/${ARCH} $OSBUILDER_IMAGE
+    # Switched from quay.io/kairos/osbuilder-tools (archived kairos-io/osbuilder
+    # + kairos-io/enki) to AuroraBoot, which is the maintained successor. The
+    # build-iso and build-uki subcommands accept a "dir:" source, so the rootfs
+    # preparation path above is unchanged; only the final CLI invocation differs.
+    FROM --platform=linux/${ARCH} $AURORABOOT_IMAGE
     ENV ISO_NAME=${ISO_NAME}
     COPY overlay/files-iso/ /overlay/
     COPY --if-exists +validate-user-data/user-data /overlay/config.yaml
@@ -416,18 +423,46 @@ build-uki-iso:
 
     WORKDIR /build
     COPY --platform=linux/${ARCH} --keep-own +iso-image-rootfs/rootfs /build/image
+    RUN mkdir /iso
     IF [ "$ARCH" = "arm64" ]
-       RUN CMD="/entrypoint.sh --name $ISO_NAME build-iso --date=false --overlay-iso /overlay dir:/build/image --output /iso/ --arch $ARCH" && \
-           if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; else CMD="$CMD"; fi && \
-              $CMD
+       # arm64 UKI ISO is not supported by upstream today; fall through to a
+       # plain live/installer ISO, matching the previous osbuilder behavior.
+       RUN CMD="auroraboot" && \
+           if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+           $CMD build-iso dir:/build/image \
+               --override-name "$ISO_NAME" \
+               --overlay-iso /overlay \
+               --output /iso/ \
+               --arch arm64
     ELSE IF [ "$ARCH" = "amd64" ]
        COPY secure-boot/enrollment/ secure-boot/private-keys/ secure-boot/public-keys/ /keys
        RUN ls -liah /keys
-       RUN mkdir /iso
+       # AuroraBoot's build-uki takes explicit key paths instead of osbuilder's
+       # bundled -k /keys. All key files live at /keys/* because the three
+       # secure-boot/* dirs above are flattened into the same target.
        IF [ "$AUTO_ENROLL_SECUREBOOT_KEYS" = "true" ]
-           RUN enki --config-dir /config build-uki dir:/build/image --extend-cmdline "$CMDLINE" --overlay-iso /overlay --secure-boot-enroll force -t iso -d /iso -k /keys --boot-branding "$BRANDING"
+           RUN CMD="auroraboot" && \
+               if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+               $CMD build-uki dir:/build/image -t iso -d /iso \
+                   --extend-cmdline "$CMDLINE" \
+                   --overlay-iso /overlay \
+                   --boot-branding "$BRANDING" \
+                   --public-keys /keys \
+                   --sb-key /keys/db.key \
+                   --sb-cert /keys/db.pem \
+                   --tpm-pcr-private-key /keys/tpm2-pcr-private.pem \
+                   --secure-boot-enroll force
        ELSE
-           RUN enki --config-dir /config build-uki dir:/build/image --extend-cmdline "$CMDLINE" --overlay-iso /overlay -t iso -d /iso -k /keys --boot-branding "$BRANDING"
+           RUN CMD="auroraboot" && \
+               if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+               $CMD build-uki dir:/build/image -t iso -d /iso \
+                   --extend-cmdline "$CMDLINE" \
+                   --overlay-iso /overlay \
+                   --boot-branding "$BRANDING" \
+                   --public-keys /keys \
+                   --sb-key /keys/db.key \
+                   --sb-cert /keys/db.pem \
+                   --tpm-pcr-private-key /keys/tpm2-pcr-private.pem
        END
     END
     WORKDIR /iso
@@ -457,7 +492,12 @@ validate-user-data:
 
 
 build-iso:
-    FROM --platform=linux/${ARCH} $OSBUILDER_IMAGE
+    # Switched from quay.io/kairos/osbuilder-tools (archived kairos-io/osbuilder
+    # + kairos-io/enki) to AuroraBoot, which is the maintained successor. The
+    # build-iso subcommand accepts a "dir:" source with the same semantics as
+    # osbuilder's /entrypoint.sh build-iso, so the rootfs preparation path
+    # above is unchanged; only the final CLI invocation differs.
+    FROM --platform=linux/${ARCH} $AURORABOOT_IMAGE
     ENV ISO_NAME=${ISO_NAME}
     COPY overlay/files-iso/ /overlay/
     COPY --if-exists +validate-user-data/user-data /overlay/files-iso/config.yaml
@@ -501,36 +541,28 @@ build-iso:
         rm -f /build/image/opt/spectrocloud/local-ui.tar; \
     fi
 
-    # Hadron uses AuroraBoot instead of osbuilder's enki: enki writes the grub
-    # stage as EFI/BOOT/grub.efi, but Hadron's shim chainloads grubx64.efi, so an
-    # enki-built Hadron ISO does not boot on any UEFI firmware. AuroraBoot names
-    # the file after its source, giving grubx64.efi. The UKI ISO
-    # boots systemd-boot directly and has no shim->grub chain.
-    IF [ "$OS_DISTRIBUTION" = "hadron" ]
-        WITH DOCKER --pull $AURORABOOT_IMAGE
-            RUN mkdir -p /iso && \
-                LOGLEVEL=info && \
-                if [ "$DEBUG" = "true" ]; then LOGLEVEL=debug; fi && \
-                docker run --rm --privileged \
-                    -v /build/image:/rootfs \
-                    -v /overlay:/overlay \
-                    -v /iso:/aurora \
-                    $AURORABOOT_IMAGE \
-                    build-iso \
-                        --loglevel "$LOGLEVEL" \
-                        --override-name "$ISO_NAME" \
-                        --overlay-iso /overlay \
-                        --output /aurora \
-                        dir:/rootfs
-        END
-    ELSE IF [ "$ARCH" = "arm64" ]
-        RUN CMD="/entrypoint.sh --name $ISO_NAME build-iso --date=false --overlay-iso /overlay dir:/build/image --output /iso/ --arch $ARCH" && \
-            if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; else CMD="$CMD"; fi && \
-                $CMD
+    # AuroraBoot uses Go arch names for both amd64 and arm64 (osbuilder used
+    # "x86_64" for amd64). The Hadron-specific WITH DOCKER path is unnecessary
+    # now that all builds are FROM $AURORABOOT_IMAGE -- AuroraBoot names the
+    # grub stage grubx64.efi (was: EFI/BOOT/grub.efi under enki), and AuroraBoot
+    # v0.26.2 fixes the UEFI-only boot path via GPT-hybrid + gcdx64.efi.signed
+    # for all distros, not just Hadron.
+    IF [ "$ARCH" = "arm64" ]
+        RUN CMD="auroraboot" && \
+            if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+            $CMD build-iso dir:/build/image \
+                --override-name "$ISO_NAME" \
+                --overlay-iso /overlay \
+                --output /iso/ \
+                --arch arm64
     ELSE IF [ "$ARCH" = "amd64" ]
-        RUN CMD="/entrypoint.sh --name $ISO_NAME build-iso --date=false --overlay-iso /overlay dir:/build/image --output /iso/ --arch x86_64" && \
-            if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; else CMD="$CMD"; fi && \
-                $CMD
+        RUN CMD="auroraboot" && \
+            if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+            $CMD build-iso dir:/build/image \
+                --override-name "$ISO_NAME" \
+                --overlay-iso /overlay \
+                --output /iso/ \
+                --arch amd64
     END
     WORKDIR /iso
     RUN sha256sum $ISO_NAME.iso > $ISO_NAME.iso.sha256

--- a/Earthfile
+++ b/Earthfile
@@ -466,7 +466,17 @@ build-uki-iso:
        END
     END
     WORKDIR /iso
-    RUN mv /iso/*.iso $ISO_NAME.iso
+    # See the equivalent block in +build-iso: AuroraBoot v0.26.1 may drop the
+    # ISO under /tmp/auroraboot instead of the requested -d, so search wherever
+    # it landed and normalize to $ISO_NAME.iso.
+    RUN ISO_SRC=$(find /iso /tmp/auroraboot -maxdepth 2 -name '*.iso' 2>/dev/null | head -n1) && \
+        if [ -z "$ISO_SRC" ]; then \
+            ISO_SRC=$(find / -xdev -name '*.iso' 2>/dev/null | head -n1); \
+        fi && \
+        if [ -z "$ISO_SRC" ]; then \
+            echo "ERROR: AuroraBoot produced no .iso file"; exit 1; \
+        fi && \
+        mv "$ISO_SRC" "/iso/$ISO_NAME.iso"
     SAVE ARTIFACT /iso/*
 
 iso:
@@ -565,11 +575,19 @@ build-iso:
                 --arch amd64
     END
     WORKDIR /iso
-    # AuroraBoot's --override-name is honored only for some source types in
-    # v0.26.1 and does not apply to "dir:" sources: the ISO comes out as
-    # kairos-<distro>-<ver>-core-<arch>-generic-v<kairos-ver>.iso. Normalize
-    # to the expected $ISO_NAME.iso the same way +build-uki-iso already does.
-    RUN mv /iso/*.iso "$ISO_NAME.iso" && \
+    # AuroraBoot v0.26.1's build-iso ignores both --output and --override-name
+    # for "dir:" sources: the ISO always lands at
+    # /tmp/auroraboot/kairos-<distro>-<ver>-core-<arch>-generic-v<kairos-ver>.iso
+    # (see the "Generating iso ... to '/tmp/auroraboot'" log line). Locate the
+    # ISO wherever it landed and normalize to $ISO_NAME.iso.
+    RUN ISO_SRC=$(find /iso /tmp/auroraboot -maxdepth 2 -name '*.iso' 2>/dev/null | head -n1) && \
+        if [ -z "$ISO_SRC" ]; then \
+            ISO_SRC=$(find / -xdev -name '*.iso' 2>/dev/null | head -n1); \
+        fi && \
+        if [ -z "$ISO_SRC" ]; then \
+            echo "ERROR: AuroraBoot produced no .iso file"; exit 1; \
+        fi && \
+        mv "$ISO_SRC" "/iso/$ISO_NAME.iso" && \
         sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
     SAVE ARTIFACT --keep-ts /iso/*
 

--- a/Earthfile
+++ b/Earthfile
@@ -561,6 +561,24 @@ build-iso:
     END
     RUN mkdir -p /iso && \
         mv /tmp/auroraboot/*.iso "/iso/$ISO_NAME.iso"
+
+    # AuroraBoot v0.26.2's `build-iso` subcommand runs only:
+    #   PrepDirs -> StepCopyCloudConfig -> StepDumpSource -> StepGenISO
+    # and NEVER calls StepInjectCC. That step is the one that actually copies
+    # --overlay-iso content onto the finalised ISO tree; its absence means our
+    # /overlay/... files (Palette-branded /boot/grub2/grub.cfg, user-data,
+    # cluster config, content bundles, edge_custom_config) silently disappear.
+    # Empirically verified: the built ISO's /boot/grub2/grub.cfg is
+    # AuroraBoot's default "Kairos"-branded template, not our overlay's
+    # "Palette eXtended Kubernetes Edge Installer" version.
+    #
+    # Pipeline mode (docker run auroraboot --set ...) invokes StepInjectCC,
+    # but that adds DinD, container_image loading, and ~100 lines of Earthfile.
+    # StepInjectCC's actual work is one xorriso command; do it here directly.
+    # See kairos-io/AuroraBoot pkg/ops/iso.go InjectISO() for the upstream
+    # equivalent -- same xorriso invocation.
+    RUN xorriso -indev "/iso/$ISO_NAME.iso" -outdev "/iso/$ISO_NAME.iso" \
+                -map /overlay / -boot_image any replay
     WORKDIR /iso
     RUN sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
     SAVE ARTIFACT --keep-ts /iso/*

--- a/Earthfile
+++ b/Earthfile
@@ -423,17 +423,15 @@ build-uki-iso:
 
     WORKDIR /build
     COPY --platform=linux/${ARCH} --keep-own +iso-image-rootfs/rootfs /build/image
-    RUN mkdir /iso
+    # AuroraBoot v0.26.1 silently ignores --output/-d for "dir:" sources on
+    # both build-iso and build-uki, dropping the ISO at /tmp/auroraboot/*.iso
+    # regardless. We hoist it into /iso/ ourselves after the run.
     IF [ "$ARCH" = "arm64" ]
        # arm64 UKI ISO is not supported by upstream today; fall through to a
        # plain live/installer ISO, matching the previous osbuilder behavior.
        RUN CMD="auroraboot" && \
            if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-           $CMD build-iso dir:/build/image \
-               --override-name "$ISO_NAME" \
-               --overlay-iso /overlay \
-               --output /iso/ \
-               --arch arm64
+           $CMD build-iso dir:/build/image --overlay-iso /overlay --arch arm64
     ELSE IF [ "$ARCH" = "amd64" ]
        COPY secure-boot/enrollment/ secure-boot/private-keys/ secure-boot/public-keys/ /keys
        RUN ls -liah /keys
@@ -443,7 +441,7 @@ build-uki-iso:
        IF [ "$AUTO_ENROLL_SECUREBOOT_KEYS" = "true" ]
            RUN CMD="auroraboot" && \
                if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-               $CMD build-uki dir:/build/image -t iso -d /iso \
+               $CMD build-uki dir:/build/image -t iso \
                    --extend-cmdline "$CMDLINE" \
                    --overlay-iso /overlay \
                    --boot-branding "$BRANDING" \
@@ -455,7 +453,7 @@ build-uki-iso:
        ELSE
            RUN CMD="auroraboot" && \
                if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-               $CMD build-uki dir:/build/image -t iso -d /iso \
+               $CMD build-uki dir:/build/image -t iso \
                    --extend-cmdline "$CMDLINE" \
                    --overlay-iso /overlay \
                    --boot-branding "$BRANDING" \
@@ -465,18 +463,8 @@ build-uki-iso:
                    --tpm-pcr-private-key /keys/tpm2-pcr-private.pem
        END
     END
-    WORKDIR /iso
-    # See the equivalent block in +build-iso: AuroraBoot v0.26.1 may drop the
-    # ISO under /tmp/auroraboot instead of the requested -d, so search wherever
-    # it landed and normalize to $ISO_NAME.iso.
-    RUN ISO_SRC=$(find /iso /tmp/auroraboot -maxdepth 2 -name '*.iso' 2>/dev/null | head -n1) && \
-        if [ -z "$ISO_SRC" ]; then \
-            ISO_SRC=$(find / -xdev -name '*.iso' 2>/dev/null | head -n1); \
-        fi && \
-        if [ -z "$ISO_SRC" ]; then \
-            echo "ERROR: AuroraBoot produced no .iso file"; exit 1; \
-        fi && \
-        mv "$ISO_SRC" "/iso/$ISO_NAME.iso"
+    RUN mkdir -p /iso && \
+        mv /tmp/auroraboot/*.iso "/iso/$ISO_NAME.iso"
     SAVE ARTIFACT /iso/*
 
 iso:
@@ -552,43 +540,29 @@ build-iso:
     fi
 
     # AuroraBoot uses Go arch names for both amd64 and arm64 (osbuilder used
-    # "x86_64" for amd64). The Hadron-specific WITH DOCKER path is unnecessary
-    # now that all builds are FROM $AURORABOOT_IMAGE -- AuroraBoot names the
-    # grub stage grubx64.efi (was: EFI/BOOT/grub.efi under enki), and AuroraBoot
-    # v0.26.2 fixes the UEFI-only boot path via GPT-hybrid + gcdx64.efi.signed
-    # for all distros, not just Hadron.
+    # "x86_64" for amd64). --output/--override-name are inert for "dir:"
+    # sources: the ISO always lands at /tmp/auroraboot/kairos-<distro>-<ver>-
+    # core-<arch>-generic-v<kairos-ver>.iso, so we leave --output default and
+    # hoist the produced ISO into /iso/ ourselves.
+    #
+    # The Hadron-specific WITH DOCKER path is unnecessary now that all builds
+    # are FROM $AURORABOOT_IMAGE -- AuroraBoot names the grub stage
+    # grubx64.efi (was: EFI/BOOT/grub.efi under enki), and AuroraBoot v0.26.2
+    # fixes the UEFI-only boot path via GPT-hybrid + gcdx64.efi.signed for all
+    # distros, not just Hadron.
     IF [ "$ARCH" = "arm64" ]
         RUN CMD="auroraboot" && \
             if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-            $CMD build-iso dir:/build/image \
-                --override-name "$ISO_NAME" \
-                --overlay-iso /overlay \
-                --output /iso/ \
-                --arch arm64
+            $CMD build-iso dir:/build/image --overlay-iso /overlay --arch arm64
     ELSE IF [ "$ARCH" = "amd64" ]
         RUN CMD="auroraboot" && \
             if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-            $CMD build-iso dir:/build/image \
-                --override-name "$ISO_NAME" \
-                --overlay-iso /overlay \
-                --output /iso/ \
-                --arch amd64
+            $CMD build-iso dir:/build/image --overlay-iso /overlay --arch amd64
     END
+    RUN mkdir -p /iso && \
+        mv /tmp/auroraboot/*.iso "/iso/$ISO_NAME.iso"
     WORKDIR /iso
-    # AuroraBoot v0.26.1's build-iso ignores both --output and --override-name
-    # for "dir:" sources: the ISO always lands at
-    # /tmp/auroraboot/kairos-<distro>-<ver>-core-<arch>-generic-v<kairos-ver>.iso
-    # (see the "Generating iso ... to '/tmp/auroraboot'" log line). Locate the
-    # ISO wherever it landed and normalize to $ISO_NAME.iso.
-    RUN ISO_SRC=$(find /iso /tmp/auroraboot -maxdepth 2 -name '*.iso' 2>/dev/null | head -n1) && \
-        if [ -z "$ISO_SRC" ]; then \
-            ISO_SRC=$(find / -xdev -name '*.iso' 2>/dev/null | head -n1); \
-        fi && \
-        if [ -z "$ISO_SRC" ]; then \
-            echo "ERROR: AuroraBoot produced no .iso file"; exit 1; \
-        fi && \
-        mv "$ISO_SRC" "/iso/$ISO_NAME.iso" && \
-        sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
+    RUN sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
     SAVE ARTIFACT --keep-ts /iso/*
 
 ### UKI targets

--- a/Earthfile
+++ b/Earthfile
@@ -565,7 +565,12 @@ build-iso:
                 --arch amd64
     END
     WORKDIR /iso
-    RUN sha256sum $ISO_NAME.iso > $ISO_NAME.iso.sha256
+    # AuroraBoot's --override-name is honored only for some source types in
+    # v0.26.1 and does not apply to "dir:" sources: the ISO comes out as
+    # kairos-<distro>-<ver>-core-<arch>-generic-v<kairos-ver>.iso. Normalize
+    # to the expected $ISO_NAME.iso the same way +build-uki-iso already does.
+    RUN mv /iso/*.iso "$ISO_NAME.iso" && \
+        sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
     SAVE ARTIFACT --keep-ts /iso/*
 
 ### UKI targets

--- a/overlay/files-iso/boot/grub2/grub.cfg
+++ b/overlay/files-iso/boot/grub2/grub.cfg
@@ -1,33 +1,56 @@
-search --file --set=root /boot/kernel.xz
+search --no-floppy --file --set=root /boot/kernel
 set default={{DEFAULT_ENTRY}}
 set timeout=5
 set timeout_style=menu
 set linux=linux
 set initrd=initrd
+
+# Video/console parameters are firmware-specific.
+#
+# BIOS/CSM: vga=795 requests VESA mode 0x31B via INT 10h from the legacy video
+#           BIOS, giving the kernel a framebuffer console. Unchanged.
+#
+# UEFI:     there is no VBE, so vga= is inert. Combined with nomodeset (which
+#           blocks the native KMS driver) the kernel ends up with no usable
+#           framebuffer and the screen stays black. The last console= also wins
+#           for /dev/console, so console=tty0 must come last or all output goes
+#           to serial. The baud is pinned because an unqualified console=ttyS0
+#           defaults to 9600 while BMC SOL typically runs at 115200.
 if [ "${grub_platform}" = "efi" ]; then
-    echo "Please press 't' to show the boot menu on this console"
+    set consoleparams="console=ttyS0,115200n8 console=tty0"
+    set videoparams=""
+else
+    set consoleparams="console=tty1 console=ttyS0"
+    set videoparams="vga=795 nomodeset"
 fi
-set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2
-if [ -f ${font} ];then
-    loadfont ${font}
+
+# loadfont switches GRUB to gfxterm. Some UEFI implementations (observed on
+# Supermicro with ATEN BMC) render nothing in that mode, leaving a blank menu,
+# so keep the graphical terminal on the BIOS path only.
+if [ "${grub_platform}" != "efi" ]; then
+    set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2
+    if [ -f ${font} ];then
+        loadfont ${font}
+    fi
 fi
+
 menuentry "Palette eXtended Kubernetes Edge Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 $consoleparams rd.cos.disable $videoparams nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette eXtended Kubernetes Edge Installer (manual)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 $consoleparams rd.cos.disable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "Palette Edge Interactive Installer" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0 interactive-install
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 $consoleparams rd.cos.disable $videoparams nodepair.enable selinux=0 rd.live.overlay.overlayfs rd.immucore.sysrootwait=600 systemd.unified_cgroup_hierarchy=1 rd.driver.blacklist=nouveau,qat_4xxx modprobe.blacklist=nouveau,qat_4xxx nouveau.modeset=0 interactive-install
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }


### PR DESCRIPTION
## Summary

Ports the AuroraBoot ISO switch from `AIL-AuroraBootISO` (targeted at `vipsharm-GPU`) to the `PE-8787` line. Ships the same UEFI-only-boot fixes and the `--overlay-iso` workaround here.

Ticket: **AIL-418**  
Companion PR against `vipsharm-GPU`: #738

## What changes

- **`AURORABOOT_VERSION` v0.21.2 → v0.26.2.** Kairos upstream fixed the two defects that were blocking UEFI-only ISO boot on strict firmware (SuperMicro ATEN BMC, VMware ESXi/Workstation, OVMF/QEMU): xorriso now emits `appended_part_as=gpt` for hybrid MBR+GPT, and the ESP now ships the CD-variant signed GRUB (`gcdx64.efi.signed`, prefix `/boot/grub`, iso9660 baked in) instead of the installed-system variant (`grubx64.efi.signed`, prefix `/EFI/ubuntu`). See kairos-io/AuroraBoot#713 + kairos-sdk v0.25.2.
- **`+build-iso` and `+build-uki-iso` switched from `$OSBUILDER_IMAGE` → `$AURORABOOT_IMAGE`.** osbuilder is archived. This is the same switch AIL-AuroraBootISO makes against vipsharm-GPU; the port is direct.
- **`+build-iso`'s Hadron-specific `WITH DOCKER` branch collapsed into the unified arm64/amd64 path.** With everything now `FROM $AURORABOOT_IMAGE`, the Hadron-specific dockerd-inside-container detour is unnecessary; AuroraBoot names the grub stage `grubx64.efi` consistently for all distros, which was the original reason the Hadron branch existed.
- **`+build-iso` ISO name normalized after AuroraBoot writes it** (`mv /tmp/auroraboot/*.iso /iso/$ISO_NAME.iso`). AuroraBoot's `--override-name` / `--output` are inert for `dir:` sources — tracked upstream as kairos-io/kairos#4284.
- **`+build-iso` xorriso post-process to apply `/overlay/`**. AuroraBoot's `build-iso` subcommand doesn't call `StepInjectCC`, so `--overlay-iso <dir>` silently drops overlay files. Same one-line xorriso invocation upstream uses in pipeline mode's `InjectISO`. Tracked upstream as kairos-io/kairos#4283, with a fix PR at kairos-io/AuroraBoot#716.
- **`overlay/files-iso/boot/grub2/grub.cfg` refactored**: `$consoleparams`/`$videoparams` now branch on `${grub_platform}` (fixes vga=795 being inert under UEFI); `loadfont` restricted to BIOS path (some firmwares blank the menu under gfxterm); `search` corrected to `/boot/kernel`. Byte-identical BIOS path. Cherry-picked from Arvind's original grub.cfg cleanup.

## What is NOT changed

- `+uki-genkey` and `+build-provider-trustedboot-image` stay on `osbuilder-tools`. Same scope decision as AIL-AuroraBootISO — those don't produce ISOs, so the UEFI-boot bug doesn't apply; they can migrate separately.
- `+build-uki-iso` uses `auroraboot build-uki -t iso` (a different upstream code path). The overlay-inject workaround is deliberately **not** applied there yet — could break UKI signing if applied naively. Follow-up needed to verify safe overlay injection into a UKI ISO.

## Commits (bottom-up)

- `1fe29df` — `Update grub.cfg` (Arvind's cleanup, cherry-picked from `4e59375`).
- `6d409d6` — `feat(iso): switch +build-iso and +build-uki-iso to AuroraBoot` (from `978a633`; version bumped to `v0.26.2` during conflict resolution; Hadron WITH DOCKER branch removed).
- `ec549cf`, `7e5c2b4`, `ae85eeb` — ISO filename normalization (from `a179757`, `c8ed02b`, `b25262e`).
- `b83ded4` — `fix(iso): xorriso-inject overlay into ISO ...` (from `9de6067`).

The 4 UEFI-workaround commits from AIL-AuroraBootISO (`271195e`, `dec346e`, `41f434f`, `629a565`) are deliberately not ported — they were later reverted upstream by AuroraBoot v0.26.2. This port goes straight to the v0.26.2 endpoint.

## Verified

- `earthly ls` — Earthfile parses cleanly.
- No osbuilder references remain in `+build-iso` / `+build-uki-iso`.
- Overlay-inject step in place at `+build-iso`.
- ISO name normalization step in place at `+build-iso` and `+build-uki-iso`.

## Not yet verified

- End-to-end pipeline ISO build against PE-8787 base (companion appliance-builder run against `vipsharm-GPU` is #31126547352 — separate test, not this branch).
- Install-and-reboot on real hardware (SuperMicro, VMware ESXi) — same status as the `vipsharm-GPU` PR.

## Upstream

- kairos-io/kairos#4283 — `build-iso` subcommand silently drops `--overlay-iso` (root cause of our workaround)
- kairos-io/kairos#4284 — `build-iso --output` / `--override-name` inert for `dir:` sources
- **kairos-io/AuroraBoot#716** — one-line fix for #4283 (adds `StepInjectCC` to the subcommand step list)

Once #716 merges and the AuroraBoot image bumps, we can drop the xorriso `-map /overlay /` post-process step from this Earthfile.

🤖 Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
