### PR TITLE
PE-8984: symlink scw into /usr/local/bin

### DIFF
--- a/cloud-images/workaround/custom-post-reset.yaml
+++ b/cloud-images/workaround/custom-post-reset.yaml
@@ -19,6 +19,7 @@ stages:
         - ln -sf /opt/spectrocloud/bin/agent-provider-stylus /usr/local/bin/agent-provider-stylus
         - ln -sf /opt/spectrocloud/bin/palette-tui /usr/local/bin/palette-tui
         - ln -sf /opt/spectrocloud/bin/helm /usr/local/bin/helm
+        - ln -sf /opt/spectrocloud/bin/scw /usr/local/bin/scw
         - journalctl > /usr/local/installer.log
         - umount /usr/local
       name: "Run after install commands"
@@ -40,6 +41,7 @@ stages:
         - ln -sf /opt/spectrocloud/bin/agent-provider-stylus /usr/local/bin/agent-provider-stylus
         - ln -sf /opt/spectrocloud/bin/palette-tui /usr/local/bin/palette-tui
         - ln -sf /opt/spectrocloud/bin/helm /usr/local/bin/helm
+        - ln -sf /opt/spectrocloud/bin/scw /usr/local/bin/scw
         - journalctl > /usr/local/installer.log
         - if mount | grep /usr/local >/dev/null; then umount /usr/local; fi
         - if [ -e /dev/mapper/persistent ]; then cryptsetup close /dev/mapper/persistent; fi

--- a/cloudconfigs/80_stylus_uki.yaml
+++ b/cloudconfigs/80_stylus_uki.yaml
@@ -12,6 +12,7 @@ stages:
         - echo "Linking agent provider"
         - mkdir -p /usr/local/bin/
         - ln -sf /opt/spectrocloud/bin/agent-provider-stylus /usr/local/bin/agent-provider-stylus
+        - ln -sf /opt/spectrocloud/bin/scw /usr/local/bin/scw
     - if: '[ -e "/run/cos/uki_boot_mode" ] && [ ! -f "/run/cos/live_mode" ] && [ ! -f "/opt/spectrocloud/bin/stylus-agent" ]'
       name: unpack stylus package
       commands:

--- a/custom-postreset.yaml
+++ b/custom-postreset.yaml
@@ -19,6 +19,7 @@ stages:
         - ln -sf /opt/spectrocloud/bin/agent-provider-stylus /usr/local/bin/agent-provider-stylus
         - ln -sf /opt/spectrocloud/bin/palette-tui /usr/local/bin/palette-tui
         - ln -sf /opt/spectrocloud/bin/helm /usr/local/bin/helm
+        - ln -sf /opt/spectrocloud/bin/scw /usr/local/bin/scw
         - journalctl > /usr/local/installer.log
         - umount /usr/local
       name: "Run after install commands"
@@ -40,6 +41,7 @@ stages:
         - ln -sf /opt/spectrocloud/bin/agent-provider-stylus /usr/local/bin/agent-provider-stylus
         - ln -sf /opt/spectrocloud/bin/palette-tui /usr/local/bin/palette-tui
         - ln -sf /opt/spectrocloud/bin/helm /usr/local/bin/helm
+        - ln -sf /opt/spectrocloud/bin/scw /usr/local/bin/scw
         - journalctl > /usr/local/installer.log
         - if mount | grep /usr/local >/dev/null; then umount /usr/local; fi
         - if [ -e /dev/mapper/persistent ]; then cryptsetup close /dev/mapper/persistent; fi


### PR DESCRIPTION
`scw` now ships inside the stylus package at `/opt/spectrocloud/bin/scw`, which is not on the default `PATH`. Link it into `/usr/local/bin` so operators can run `scw triage cluster` directly, matching how `agent-provider-stylus`, `palette-tui` and `helm` are already handled.

`/usr/local` is the persistent partition mounted over the image, so the link cannot be baked in — it has to be recreated wherever that partition is established.

## Changes

| File | Change |
|---|---|
| `custom-postreset.yaml` | `ln -sf …/scw /usr/local/bin/scw` in the post-reset and UKI post-reset stanzas |
| `cloud-images/workaround/custom-post-reset.yaml` | same two stanzas |
| `cloudconfigs/80_stylus_uki.yaml` | same link in the UKI boot stanza |

3 files, +5.

No build change: CanvOS consumes the published stylus framework image, which is `FROM package`, so the binary arrives on its own.

Pairs with spectrocloud/stylus#6277.

Refs: PE-8984
