### PR TITLE
PE-9246: dedup boot-assessment OEM stages on SLE Micro 5.5

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1289,16 +1289,6 @@ iso-image:
     END
     COPY overlay/files/ /
 
-    # Workaround for kairos-agent v2.30.2 install-time mount-lifecycle bug on
-    # SLE Micro Rancher 5.5: /system/oem/08_grub.yaml's after-install "Grub
-    # branding" cp writes to a tmpfs path that is lost on reboot, so
-    # /grubmenu never lands on the persistent state partition and GRUB
-    # cannot find the Palette Registration menuentry. See
-    # slem/5.5/oem/09_grub_branding_fixup.yaml for full explanation.
-    IF [ "$OS_DISTRIBUTION" = "sles" ] && [ "$OS_VERSION" = "5.5" ]
-        COPY slem/5.5/oem/09_grub_branding_fixup.yaml /system/oem/09_grub_branding_fixup.yaml
-    END
-
     IF [ "$IS_CLOUD_IMAGE" = "true" ]
         COPY cloud-images/workaround/grubmenu.cfg /etc/kairos/branding/grubmenu.cfg
         COPY cloud-images/workaround/custom-post-reset.yaml /system/oem/custom-post-reset.yaml

--- a/slem/5.5/Dockerfile
+++ b/slem/5.5/Dockerfile
@@ -50,6 +50,15 @@ RUN rpm --import /tmp/suse-build-key.asc && rm -f /tmp/suse-build-key.asc && \
 # SLE Micro for Rancher ships Rancher Elemental, a competing immutable-OS stack.
 # Its dracut modules, systemd services and /system/oem layout files race with
 # Kairos immucore and prevent sysroot.mount from landing. Remove before kairos-init.
+#
+# PE-9246: /system/oem/08_boot_assessment.yaml is an Elemental artifact too --
+# it defines the same GRUB boot-assessment hook that kairos-init later
+# re-implements in /system/oem/08_grub.yaml, and both files' after-install
+# steps append the same source block to /run/initramfs/cos-state/grubcustom,
+# so on the first post-upgrade boot GRUB runs the assessment twice in one
+# session and immediately picks fallback with upgrade_failure. The file has
+# no "elemental" in its name, so the *_elemental-* glob below misses it;
+# list it explicitly.
 RUN zypper --non-interactive rm -y --clean-deps \
         elemental elemental-register1.5 elemental-support1.5 \
         elemental-system-agent elemental-toolkit elemental-updater \
@@ -63,13 +72,23 @@ RUN zypper --non-interactive rm -y --clean-deps \
       systemctl mask "${svc}.service" 2>/dev/null || true; \
     done; \
     rm -f /system/oem/*_elemental-* \
+          /system/oem/08_boot_assessment.yaml \
           /etc/dracut.conf.d/99-elemental-systemd.conf \
           /etc/dracut.conf.d/02-elemental-immutable-rootfs.conf \
           /etc/dracut.conf.d/02-elemental-setup-initramfs.conf \
           /etc/dracut.conf.d/50-elemental-initrd.conf
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -m "generic" -t "${TRUSTED_BOOT}" --version "${KAIROS_VERSION}" && rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -m "generic" -t "${TRUSTED_BOOT}" --version "${KAIROS_VERSION}"
+
+# Workaround for a kairos-agent v2.30.2 install-time mount-lifecycle bug:
+# 08_grub.yaml's after-install "Grub branding" cp writes /grubmenu to
+# /tmp/mnt/STATE, which is a tmpfs directory on SUSE because COS_STATE is
+# already mounted at /run/cos/state and kairos's own Mount step therefore
+# fails. The file is lost on reboot and GRUB cannot find the Palette
+# Registration menuentry. This overlay re-does the copy in
+# after-install-chroot against /oem (COS_OEM, which GRUB also searches).
+COPY oem/09_grub_branding_fixup.yaml /system/oem/09_grub_branding_fixup.yaml
 
 # Scrub subscription data so credentials do not ship in the final image.
 RUN rm -rf /etc/zypp/credentials.d/* /etc/zypp/services.d/* /etc/SUSEConnect 2>/dev/null || true

--- a/slem/5.5/oem/09_grub_branding_fixup.yaml
+++ b/slem/5.5/oem/09_grub_branding_fixup.yaml
@@ -16,8 +16,8 @@ name: "SLE Micro 5.5 grubmenu fixup"
 # after-install-chroot bind-mounts COS_OEM at /oem inside the target chroot
 # and is confirmed to fire cleanly on SUSE.
 #
-# This file is COPY-ed only into SLE Micro 5.5 builds by the Earthfile
-# iso-image target -- do not add a runtime OS guard here.
+# This file is COPY-ed only into SLE Micro 5.5 builds by slem/5.5/Dockerfile
+# (the SLE Micro 5.5 base image) -- do not add a runtime OS guard here.
 stages:
   after-install-chroot:
     - name: "Copy branding grubmenu to OEM"


### PR DESCRIPTION
## Summary
- Remove SUSE-shipped `/system/oem/08_boot_assessment.yaml` from the SLE Micro 5.5 base image. It's a Rancher Elemental artifact whose filename lacks `elemental`, so the existing cleanup glob misses it. It defines the same GRUB boot-assessment hook that kairos-init later re-implements in `/system/oem/08_grub.yaml`; both files append the same source block to `grubcustom`, causing GRUB to trip fallback-to-passive with `upgrade_failure` on the first post-upgrade boot before the new active image is ever booted.
- Switch the `kairos-init` invocation to `RUN --mount=type=bind` so the binary doesn't land in an image layer (plus a whiteout in the next).
- Move the `09_grub_branding_fixup.yaml` copy from `Earthfile:iso-image` into `slem/5.5/Dockerfile` so installer and provider images both pick it up from the base.

Fixes PE-9246.

## Test plan
- [ ] Rebuild the base image with `slem/5.5/build.sh <SCC_REGCODE>`
- [ ] Confirm `/system/oem/08_boot_assessment.yaml` is absent, `/system/oem/08_grub.yaml` and `/system/oem/09_grub_branding_fixup.yaml` are present, and `/kairos-init` does not appear in any layer of the built image
- [ ] Rebuild ISO + provider on top; provision an SLE Micro 5.5 edge host end-to-end and confirm it boots active after the first cluster-provisioning upgrade (no `upgrade_failure`), K3s comes up, cluster asset registers in Hubble