### PR TITLE
AIL-418: fix(iso): reorder auroraboot positional source arg to end (fixes USB boot regression)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -574,35 +574,25 @@ build-iso:
     # grubx64.efi (was: EFI/BOOT/grub.efi under enki), and AuroraBoot v0.26.2
     # fixes the UEFI-only boot path via GPT-hybrid + gcdx64.efi.signed for all
     # distros, not just Hadron.
+    # Positional source MUST come last. AuroraBoot uses urfave/cli v2 which
+    # follows Go stdlib flag semantics: flag parsing stops at the first
+    # positional argument. If dir:/build/image comes first, --overlay-iso
+    # and --arch are silently discarded as extra positional args. That is
+    # what caused the Palette-branded /boot/grub2/grub.cfg (and user-data,
+    # content bundles, cluster config) to silently disappear from produced
+    # ISOs before this fix. Empirically verified against v0.26.2.
+    # +build-uki-iso above already uses this ordering.
     IF [ "$ARCH" = "arm64" ]
         RUN CMD="auroraboot" && \
             if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-            $CMD build-iso dir:/build/image --overlay-iso /overlay --arch arm64
+            $CMD build-iso --overlay-iso /overlay --arch arm64 dir:/build/image
     ELSE IF [ "$ARCH" = "amd64" ]
         RUN CMD="auroraboot" && \
             if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-            $CMD build-iso dir:/build/image --overlay-iso /overlay --arch amd64
+            $CMD build-iso --overlay-iso /overlay --arch amd64 dir:/build/image
     END
     RUN mkdir -p /iso && \
         mv /tmp/auroraboot/*.iso "/iso/$ISO_NAME.iso"
-
-    # AuroraBoot v0.26.2's `build-iso` subcommand runs only:
-    #   PrepDirs -> StepCopyCloudConfig -> StepDumpSource -> StepGenISO
-    # and NEVER calls StepInjectCC. That step is the one that actually copies
-    # --overlay-iso content onto the finalised ISO tree; its absence means our
-    # /overlay/... files (Palette-branded /boot/grub2/grub.cfg, user-data,
-    # cluster config, content bundles, edge_custom_config) silently disappear.
-    # Empirically verified: the built ISO's /boot/grub2/grub.cfg is
-    # AuroraBoot's default "Kairos"-branded template, not our overlay's
-    # "Palette eXtended Kubernetes Edge Installer" version.
-    #
-    # Pipeline mode (docker run auroraboot --set ...) invokes StepInjectCC,
-    # but that adds DinD, container_image loading, and ~100 lines of Earthfile.
-    # StepInjectCC's actual work is one xorriso command; do it here directly.
-    # See kairos-io/AuroraBoot pkg/ops/iso.go InjectISO() for the upstream
-    # equivalent -- same xorriso invocation.
-    RUN xorriso -indev "/iso/$ISO_NAME.iso" -outdev "/iso/$ISO_NAME.iso" \
-                -map /overlay / -boot_image any replay
     WORKDIR /iso
     RUN sha256sum "$ISO_NAME.iso" > "$ISO_NAME.iso.sha256"
     SAVE ARTIFACT --keep-ts /iso/*


### PR DESCRIPTION
## Summary

Fixes the USB-boot regression introduced by PR #739's xorriso post-process by addressing the actual root cause: **AuroraBoot's `build-iso` subcommand was being invoked with the positional `dir:/build/image` before the flags**, causing `--overlay-iso` and `--arch` to be silently discarded.

Ticket: **AIL-418**  
Companion PR (same fix on `vipsharm-GPU`): #750

## Root cause

AuroraBoot uses `urfave/cli` v2 which follows Go stdlib `flag` semantics: **flag parsing stops at the first positional argument.** PR #739 shipped this invocation:

```
$CMD build-iso dir:/build/image --overlay-iso /overlay --arch amd64
              ^^^^^^^^^^^^^^^^ positional first
                               ^^^^^^^^^^^^^^^^^^^ silently discarded
```

`--overlay-iso` and `--arch` were treated as extra positional args and dropped without warning. The produced ISO had AuroraBoot's default Kairos-branded `grub.cfg` instead of our Palette overlay, no user-data, no content bundles, no cluster config, no `edge_custom_config`.

To work around that, #739 also shipped a `xorriso -indev X -outdev X -map /overlay / -boot_image any replay` post-process to inject the overlay files after AuroraBoot ran. That xorriso repack **extended the ISO9660 data past AuroraBoot's original GPT p1 end**. On USB boot, dracut mounts `/dev/sdb1` (the partition) and the kernel ISOFS driver can't reach the new root directory extent, failing with:

```
ISOFS: unable to read i-node block
isofs_fill_super: get root inode failed
mount: /run/initramfs/live: can't read superblock on /dev/sdb1
```

Reproduced on Intel NUC (Tiger Lake) via USB and via loopback mount on a Linux host.

## Empirical proof of the arg-parse bug (AuroraBoot v0.26.2)

```
# positional first — what #739 shipped
$ auroraboot build-iso dir:/tmp --overlay-iso /nope --arch amd64
  -> proceeds, --overlay-iso /nope silently dropped (fails later at kernel search)

# positional last — this fix
$ auroraboot build-iso --overlay-iso /nope --arch amd64 dir:/tmp
  -> "invalid path '/nope'" — flag actually parsed
```

Same bug applies to `--sb-key`, `--sb-cert`, `--tpm-pcr-private-key` on `build-uki`. Interestingly, `+build-uki-iso` in this branch was already using the positional-last shape — that's why UKI ISOs build correctly on `PE-8787` today. Only `+build-iso` was written with the positional-first shape.

## What this PR changes

**One block in `Earthfile` — the `+build-iso` AuroraBoot invocation:**

```diff
 IF [ "$ARCH" = "arm64" ]
     RUN CMD="auroraboot" && \
         if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-        $CMD build-iso dir:/build/image --overlay-iso /overlay --arch arm64
+        $CMD build-iso --overlay-iso /overlay --arch arm64 dir:/build/image
 ELSE IF [ "$ARCH" = "amd64" ]
     RUN CMD="auroraboot" && \
         if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
-        $CMD build-iso dir:/build/image --overlay-iso /overlay --arch amd64
+        $CMD build-iso --overlay-iso /overlay --arch amd64 dir:/build/image
 END
 RUN mkdir -p /iso && \
     mv /tmp/auroraboot/*.iso "/iso/$ISO_NAME.iso"

-# ... xorriso post-process comment block deleted ...
-RUN xorriso -indev "/iso/$ISO_NAME.iso" -outdev "/iso/$ISO_NAME.iso" \
-            -map /overlay / -boot_image any replay
```

Net diff: **+10 / -20 lines**.

## Alternative approach considered (and rejected as heavier)

An earlier revision of this PR converted `+build-iso` to DinD/pipeline mode (`FROM earthly/dind + WITH DOCKER + docker run auroraboot --set container_image=... --set iso.overlay_iso=...`), matching the pattern already used by `+cloud-image` and `+kairos-raw-image`. That worked and was boot-verified end-to-end on Intel NUC USB and SuperMicro UEFI-only — pipeline mode is all `--set key=value` with no positional argument, so nothing truncates flag parsing.

But it was ~350 lines of Earthfile refactor to work around what turned out to be a 3-line argument-reorder bug. This PR uses the smaller, more direct fix.

## Follow-ups (not in this PR)

1. **Upstream AuroraBoot PR**: reject unexpected positional args on `build-iso` and `build-uki` subcommands so this class of bug fails loudly. Silent drop is the real defect; it cost this thread about a week of debugging.

2. **Close kairos-io/AuroraBoot#716** (my earlier no-op PR). jimmykarily's herd analysis was correct that `StepInjectCC` is `Ignored=true` on the subcommand path — the ISO code path was never the problem.

## Related

- Companion PR against `vipsharm-GPU`: #750
- Upstream issues (still valid): kairos-io/kairos#4283 (subcommand `--overlay-iso` silent drop — this PR confirms the mechanism), kairos-io/kairos#4284

🤖 Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
