### PR TITLE
PE-9291: build provider trustedboot UKI with AuroraBoot

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -929,10 +929,19 @@ provider-image-rootfs:
     SAVE ARTIFACT --keep-own /. rootfs
 
 build-provider-trustedboot-image:
-    FROM --platform=linux/${ARCH} $OSBUILDER_IMAGE
+    FROM --platform=linux/${ARCH} $AURORABOOT_IMAGE
     COPY --platform=linux/${ARCH} --keep-own +provider-image-rootfs/rootfs /build/image
     COPY secure-boot/enrollment/ secure-boot/private-keys/ secure-boot/public-keys/ /keys
-    RUN /entrypoint.sh build-uki dir:/build/image -t container -d /output -k /keys --boot-branding "Palette eXtended Kubernetes Edge"
+    RUN mkdir -p /output
+    RUN CMD="auroraboot" && \
+        if [ "$DEBUG" = "true" ]; then CMD="$CMD --debug"; fi && \
+        $CMD build-uki -t container -d /output \
+            --boot-branding "$BRANDING" \
+            --public-keys /keys \
+            --sb-key /keys/db.key \
+            --sb-cert /keys/db.pem \
+            --tpm-pcr-private-key /keys/tpm2-pcr-private.pem \
+            dir:/build/image
     SAVE ARTIFACT /output/* AS LOCAL ./trusted-boot/
 
 stylus-image:


### PR DESCRIPTION
## Summary
- Switch `+build-provider-trustedboot-image` from `$OSBUILDER_IMAGE` (enki) to `$AURORABOOT_IMAGE`, mirroring `+build-uki-iso`.
- Align the systemd-boot binary shipped inside the provider-image UKI with the one on the installer ESP; without this, the older enki-bundled sd-boot overwrites `BOOTX64.EFI` at install time and stops parsing the `uki` / `profile` directives that AuroraBoot writes into `recovery+3.conf` / `statereset+3.conf`, silently breaking reset on provisioned nodes.

## Test plan
- [x] Build provider image with the new target — `.sbat` in `/trusted-boot/EFI/BOOT/BOOTX64.EFI` reads `systemd-boot, 259, kairos-259` (was `256, kairos-256.7`).
- [x] Fresh install of the v0.16.3 UKI ISO, provision with the new provider image, trigger reset — verify `kairos-reset.service` runs and node returns to registration state.