### PR TITLE
ci(security): pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -17,7 +17,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947 # v9.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-

--- a/.github/workflows/base-images.yaml
+++ b/.github/workflows/base-images.yaml
@@ -174,17 +174,17 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to registry
         run: echo "${{ secrets.US_EAST_JSON_KEY_B64 }}" | base64 -d | docker login -u _json_key --password-stdin us-east1-docker.pkg.dev
 
       - name: Build and push kairosify image
         if: matrix.builder == 'kairosify'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
           files: docker-bake-kairosify.hcl
           targets: kairosify
@@ -251,7 +251,7 @@ jobs:
           } >> /tmp/results/built_tags.txt
 
       - name: Upload build results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-result-${{ matrix.name }}
           path: /tmp/results/built_tags.txt
@@ -266,7 +266,7 @@ jobs:
       built_tags: ${{ steps.combine-tags.outputs.tags }}
     steps:
       - name: Download all build results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: build-result-*
           path: /tmp/results


### PR DESCRIPTION
## Summary

Follow-up to the zizmor findings on #682. Pins the six third-party actions referenced in `.github/workflows/backport.yaml` and `.github/workflows/base-images.yaml` to full commit SHAs so a compromised or hijacked tag can't swap out the referenced code. Version comments are retained for readability.

| Action | SHA | Version |
|---|---|---|
| `sorenlouv/backport-github-action` | `ad888e978060bc1b2798690dd9d03c4036560947` | v9.5.1 |
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | v4 |
| `docker/setup-buildx-action` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` | v3 |
| `docker/bake-action` | `5be5f02ff8819ecd3092ea6b2e6261c31774f2b4` | v6 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
| `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4 |

Per Santhosh's DM guidance, this PR scopes to `unpinned-uses` only. Remaining zizmor findings from the #682 run:
- `template-injection` in `base-images.yaml` — inputs come from `workflow_dispatch` (maintainer-triggered), not attacker-controllable; can be addressed separately if we want to appease the linter (move inputs into `env:` and reference `${VAR}`).
- `dangerous-triggers` on `backport.yaml` — `pull_request_target` is required by design for the auto-backport flow.

## Test plan

- [x] Zizmor re-scan shows the six `unpinned-uses` findings gone.