### PR TITLE
PE-9173: install open-vm-tools in Ubuntu 22.04 FIPS base image

### DIFF
--- a/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
+++ b/ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips
@@ -24,7 +24,11 @@ RUN --mount=type=secret,id=pro-attach-config \
     && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
     && pro attach --attach-config /run/secrets/pro-attach-config \
     && apt-get upgrade -y \
-    && apt-get install -y strongswan strongswan-hmac openssh-client openssh-server linux-image-fips linux-headers-fips shim-signed cracklib-runtime \
+    ## open-vm-tools: kairos-init installs the VMware guest agent for the SUSE family but not
+    ## for Debian/Ubuntu. Without vmtoolsd running, vSphere reports blank IP Addresses / DNS
+    ## Name for the guest (PE-9173). Not a crypto module, so no FIPS impact. The 20.04 and
+    ## 24.04 FIPS images already install it here; this brings 22.04 to parity.
+    && apt-get install -y strongswan strongswan-hmac openssh-client openssh-server linux-image-fips linux-headers-fips shim-signed open-vm-tools cracklib-runtime \
     ## && pro enable usg \
     ## && apt install -y usg \
     ## && usg fix disa_stig \


### PR DESCRIPTION
## Summary

Adds `open-vm-tools` to the **Ubuntu 22.04 FIPS** base image so vSphere / vCenter can report the guest **IP Addresses** and **DNS Name**.

`kairos-init` installs the VMware guest agent for the SUSE family but **not** for Debian/Ubuntu. Without `vmtoolsd` running, vCenter shows blank IP/DNS and `VMware Tools: Not running, not installed`.

## Why 22.04 FIPS specifically

- PR #682 (PE-8787 / PE-9173) fixed the **non-FIPS core** path by installing `open-vm-tools` in the kairosify Dockerfile.
- The **20.04** and **24.04** FIPS Dockerfiles already carry `open-vm-tools` in their apt install lists.
- The **22.04** FIPS Dockerfile was the only Ubuntu image still missing it — matching the field report on PE-9173 ("seeing this for ubuntu22 fips alone in latest build").

## Change

Add `open-vm-tools` to the PRO-attached apt install list in `ubuntu-fips/22.04/Dockerfile.ubuntu22.04-fips`, positioned exactly as in the 24.04 sibling (`shim-signed open-vm-tools cracklib-runtime`).

`open-vm-tools` is **not** a cryptographic module, so it has **no FIPS impact**. The package ships its own `open-vm-tools.service` unit (gated on VMware virtualization), so it is inert on bare-metal / KVM.

## Test plan

- [x] Build the Ubuntu 22.04 FIPS base image
- [ ] Deploy an Edge host from it on vSphere
- [ ] vCenter shows **VMware Tools = Running**, populated **IP Addresses** and **DNS Name**
- [ ] `systemctl status open-vm-tools` → active; `dpkg -l open-vm-tools` → installed

Refs: PE-9173, PE-8787
