### PR TITLE
fix(base-image): hold console-setup so the apt upgrade does not break the provider-image build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -865,7 +865,12 @@ base-image:
         # tldr: apt-get upgrade -y doesn't install new packages, so we need to use --with-new-pkgs
 
         IF [ "$IS_UKI" = "false" ]
+            # Hold console-setup before the upgrade. Its 1.226ubuntu1.1 postinst prompts
+            # via debconf (uninitialized DB -> sed "unterminated s command" -> exit 128),
+            # which breaks this non-interactive image build. Freeze it at the base-image
+            # version so apt-get upgrade keeps it back.
             RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+                apt-mark hold console-setup console-setup-linux && \
                 apt-get upgrade $APT_UPGRADE_FLAGS && \
                 apt-get install --no-install-recommends -y \
                     util-linux \ # Provides essential utilities for Linux systems, including disk management tools.


### PR DESCRIPTION
## Problem

The provider-image build (CanvOS `+base-image`) started failing on 2026-08-21.

- **Worked:** 2026-08-20 — content build [run 32360517180](https://github.com/spectrocloud/appliance-builder/actions/runs/32360517180) succeeded on this same `vipsharm-GPU` branch.
- **Failed:** 2026-08-21 — content build [run 32445360288](https://github.com/spectrocloud/appliance-builder/actions/runs/32445360288) failed (both NVIDIA and AMD), same branch, same inputs.

Nothing in the branch changed between the two runs. The cause is an upstream Ubuntu package.

The base-image step runs `apt-get upgrade`. On 2026-08-21 that upgrade pulled the newly published **`console-setup 1.226ubuntu1.1`**. Its post-install script prompts through debconf. In this non-interactive image build the debconf database has an uninitialized value, so the script builds a broken `sed` expression and fails:

```
Configuring console-setup
Use of uninitialized value ... at /usr/share/perl5/Debconf/DbDriver/Stack.pm line 112
sed: -e expression #1, char 8: unterminated `s' command
dpkg: error processing package console-setup (--configure): ... exit status 128
```

`dpkg` then returns an error and the whole provider-image build stops at `Earthfile`.

## Fix

Hold `console-setup` and `console-setup-linux` before the upgrade, so `apt-get upgrade` keeps them back at the base-image version and the broken post-install never runs.

```
apt-mark hold console-setup console-setup-linux && \
```

This is a one-line change in the `IS_UKI = false` base-image block. It does not change the kernel — this branch keeps the **6.17.0-35** kernel it targets. It only stops the broken console-setup post-install from running during the build.

## Test plan

- Trigger a content build on `vipsharm-GPU` (both GPU variants).
- Confirm the `+base-image` step completes and the provider image builds.
- Confirm the kernel in the built image is still `6.17.0-35-generic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)