### PR TITLE
fix: keep Ubuntu apt upgrades noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ COPY overlay/files/etc/spectrocloud/custom-hardware-specs-lookup.json /etc/spect
 ### To install the DRBD module package for Piraeus pack on Ubuntu  ###
 
 # RUN apt-get update && \
-#     apt-get upgrade -y && \
-#     apt-get install --no-install-recommends -y \
+#     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+#     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
 #       ca-certificates \
 #       kmod \
 #       gpg \

--- a/Earthfile
+++ b/Earthfile
@@ -990,7 +990,8 @@ base-image:
                 if dpkg -l linux-image-generic > /dev/null; then apt-mark hold linux-image-generic linux-headers-generic linux-generic; fi
         ELSE
             SET APT_UPGRADE_FLAGS="-y --with-new-pkgs"
-            RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+            RUN export DEBIAN_FRONTEND=noninteractive && \
+                apt-get update && \
                 apt-get install -y linux-image-generic-hwe-$OS_VERSION
         END
 
@@ -998,7 +999,8 @@ base-image:
         # tldr: apt-get upgrade -y doesn't install new packages, so we need to use --with-new-pkgs
 
         IF [ "$IS_UKI" = "false" ]
-            RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+            RUN export DEBIAN_FRONTEND=noninteractive && \
+                apt-get update && \
                 apt-get upgrade $APT_UPGRADE_FLAGS && \
                 apt-get install --no-install-recommends -y \
                     util-linux \ # Provides essential utilities for Linux systems, including disk management tools.


### PR DESCRIPTION
## Summary
- Export `DEBIAN_FRONTEND=noninteractive` for the full Ubuntu `+base-image` apt `RUN`s so `upgrade`/`install` inherit it, not just `apt-get update`.
- Prefix `DEBIAN_FRONTEND=noninteractive` on the commented DRBD `apt-get upgrade`/`install` lines, keeping `# RUN apt-get update && \` unchanged for the teams sed matcher.

Ubuntu 24.04 `console-setup` 1.226ubuntu1.1 was prompting for a keyboard layout in headless CI and failing dpkg with exit 20.

## Test plan
- [ ] Re-run Ubuntu 24.04 ISO image build (`+iso-disk-image`) and confirm `+base-image` apt upgrade succeeds
- [ ] Re-run the DRBD-enabled Ubuntu 24.04 image build after teams uncomments the Dockerfile block
