### PR TITLE
Enable qemu-guest-agent in Ubuntu Dockerfile customizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,14 @@ COPY overlay/files/etc/spectrocloud/custom-hardware-specs-lookup.json /etc/spect
 #    apt-get install iputils-ping -y && \
 #    mkdir /var/lib/wpa
 
-# Ubuntu / Debian
-#RUN if [ "${OS_DISTRIBUTION}" = "ubuntu" ]; then \
-#      apt-get install -y qemu-guest-agent; \
-#    fi
+# Install qemu-guest-agent for Ubuntu (needed for VM guest integration on
+# provider images and slim/installer ISOs built via +base-image).
+RUN if [ "${OS_DISTRIBUTION}" = "ubuntu" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends qemu-guest-agent && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 ### To install the DRBD module package for Piraeus pack on Ubuntu  ###
 


### PR DESCRIPTION
## Summary
- Enable `qemu-guest-agent` installation for Ubuntu in the root `Dockerfile` customization layer.
- This flows into both provider images and slim/installer ISOs via `+base-image` (`FROM DOCKERFILE`), so slim ISO builds that skip the provider-image CI patch still get the package.

## Test plan
- [ ] Build a non-FIPS Ubuntu ISO (`./earthly.sh +iso`) from this branch and confirm `qemu-guest-agent` is present in the installer rootfs / ISO image
- [ ] Build a provider image (`./earthly.sh +build-provider-images`) and confirm `qemu-guest-agent` is installed
- [ ] Verify Ubuntu-only gating: non-Ubuntu OS_DISTRIBUTION builds are unaffected


Made with [Cursor](https://cursor.com)