### PR TITLE
PE-9386: pass custom Docker build args via CUSTOM_ARG_ prefix

### DIFF
--- a/.arg.template
+++ b/.arg.template
@@ -14,6 +14,20 @@ CIS_HARDENING=false
 EDGE_CUSTOM_CONFIG=.edge-custom-config.yaml
 FORCE_INTERACTIVE_INSTALL=false
 
+# Custom Docker build arguments
+# ------------------------------
+# To pass a value into a custom `ARG` you added to ./Dockerfile, declare it here
+# with the CUSTOM_ARG_ prefix. The build wrapper injects the value into the
+# matching `ARG NAME` line before Earthly runs (the upstream Earthfile forwards
+# only a fixed --build-arg list, so a plain NAME=value here would NOT reach your
+# Dockerfile). Every entry must have a matching `ARG NAME` in ./Dockerfile or
+# the build fails with a clear error (no more silent drops). Do NOT put secrets
+# here - build args leak into `docker history` and the build cache.
+#
+# Example (with `ARG BRAND` and `ARG DHCP_VENDOR_CLASS` declared in Dockerfile):
+# CUSTOM_ARG_BRAND=acme
+# CUSTOM_ARG_DHCP_VENDOR_CLASS=retail
+
 # MAAS Image Configuration
 # MAAS_IMAGE_NAME=kairos-ubuntu-maas    # Custom name for the final MAAS image (without .raw.gz extension)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CanvOS is designed to leverage the Spectro Cloud Edge Forge architecture to buil
 
 With CanvOS, we leverage Earthly to build all of the artifacts required for edge deployments. From the installer iso to the Kubernetes Provider images, CanvOS makes it simple for you to build the images customized to your needs.
 
-The base image definitions reside in the Earthfile located in this repo. This defines all of the elements that are required for building the artifacts that can be used by Palette for edge deployments. If customized packages need to be added, simply add the reference to the Dockerfile as you would for any Docker image. When the build command is run, the Earthfile will merge those custom packages into the final image. For a quickstart tutorial see the Knowledgebase section of the Spectro Cloud Docs. There you will find a quickstart tutorial for building your first CanvOS artifacts.
+The base image definitions reside in the Earthfile located in this repo. This defines all of the elements that are required for building the artifacts that can be used by Palette for edge deployments. If customized packages need to be added, simply add the `RUN`/`COPY`/`ADD` instructions to the Dockerfile as you would for any Docker image, and they will be included in the build process and output artifacts. If your customization needs a custom Docker build argument (`ARG`), see [Custom Docker Build Arguments](#custom-docker-build-arguments) — plain `ARG`s do not receive values from `.arg` automatically. For a quickstart tutorial see the Knowledgebase section of the Spectro Cloud Docs. There you will find a quickstart tutorial for building your first CanvOS artifacts.
 
 <h1 align="center">
   <br>
@@ -29,6 +29,46 @@ From the base image, this image is used to provide the initial flashing of a dev
 ### Custom Configuration
 
 For advanced use cases, there may be a need to add additional packages not included in the [Base Images](https://github.com/kairos-io/kairos/tree/master/images). If those packages or configuration elements need to be added, they can be included in the empty `Dockerfile` located in this repo and they will be included in the build process and output artifacts.
+
+### Custom Docker Build Arguments
+
+If a Dockerfile customization needs a build-time value that varies per build — for example a brand identifier or a DHCP vendor class used to produce different images from one Dockerfile — declare a custom `ARG` in `./Dockerfile` and supply its value from `.arg` using the `CUSTOM_ARG_` prefix.
+
+> **Why the prefix is required.** The Earthfile's `base-image` target forwards only a fixed `--build-arg` list into your Dockerfile (`BASE`, `OS_*`, proxies, `DRBD_VERSION`), and Earthly's `FROM DOCKERFILE` cannot forward build arguments dynamically. A plain `NAME=value` in `.arg` therefore never reaches your Dockerfile — the `ARG` silently keeps its default. The `earthly.sh` wrapper bridges this gap for `CUSTOM_ARG_*` entries by injecting the value into the matching `ARG` line before the build runs. The upstream Earthfile is never modified.
+
+**Usage**
+
+1. Declare the `ARG` in `./Dockerfile` (a default is optional):
+
+   ```dockerfile
+   ARG BRAND
+   ARG DHCP_VENDOR_CLASS=default-class
+   ```
+
+2. Set the value in `.arg` with the `CUSTOM_ARG_` prefix:
+
+   ```bash
+   CUSTOM_ARG_BRAND=acme
+   CUSTOM_ARG_DHCP_VENDOR_CLASS=retail
+   ```
+
+3. Build as usual (`./earthly.sh +build-all-images`, `+iso`, etc.). Before the build, the wrapper prints exactly what it did:
+
+   ```
+   Custom Docker build args:
+     injected:        BRAND=acme DHCP_VENDOR_CLASS=retail
+   ```
+
+**Fail-closed behavior.** The original defect was that a missing custom value failed *silently*. The wrapper now aborts the build with a clear message if:
+
+- a `CUSTOM_ARG_<NAME>` has no matching `ARG <NAME>` in the Dockerfile (a typo or a missing declaration);
+- `<NAME>` is an Earthfile-managed arg (`BASE`, `OS_DISTRIBUTION`, proxies, …) — set those via their normal `.arg` key;
+- a `CUSTOM_ARG_<NAME>` value is empty;
+- a custom `ARG` in the Dockerfile has no default **and** no value on an image/ISO build.
+
+To intentionally allow an empty/optional value, give the `ARG` an inline default in the Dockerfile (`ARG NAME=`).
+
+> **Secrets:** do **not** pass secrets as custom build args — build args are recorded in `docker history` and the build cache. Use the Ubuntu Pro / `--secret` flow instead (see `.arg` comments).
 
 ### Custom Hardware Specs Lookup
 

--- a/earthly.sh
+++ b/earthly.sh
@@ -176,6 +176,17 @@ if [ -n "$PROXY_CERT_PATH" ]; then
     cp $PROXY_CERT_PATH certs/
 fi
 
+# Custom Docker build arguments: rewrite the user Dockerfile's `ARG` defaults
+# from CUSTOM_ARG_* entries in .arg before Earthly runs. The Earthfile only
+# forwards a fixed --build-arg list and `FROM DOCKERFILE` cannot forward args
+# dynamically, so this wrapper bridges the gap (fail-closed; upstream Earthfile
+# untouched; original Dockerfile restored on exit). See scripts/custom-build-args.sh
+# for the full mechanism, guards, and the "Passing custom Docker build
+# arguments" section of the README.
+# shellcheck source=scripts/custom-build-args.sh
+source "$(dirname "$0")/scripts/custom-build-args.sh"
+inject_custom_build_args "${1:-}"
+
 ALPINE_IMG=$SPECTRO_PUB_REPO/edge/canvos/alpine:3.20
 ### Verify Dependencies
 # Check if Docker is installed

--- a/scripts/custom-build-args.sh
+++ b/scripts/custom-build-args.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# custom-build-args.sh
+#
+# Pass custom Docker build arguments into the user Dockerfile in CanvOS.
+#
+# WHY THIS EXISTS
+#   The Earthfile's base-image target forwards only a FIXED --build-arg list
+#   into ./Dockerfile (BASE, OS_*, proxies, DRBD_VERSION), and Earthly's
+#   `FROM DOCKERFILE` cannot forward build args dynamically. So any custom
+#   `ARG` a user adds to ./Dockerfile never receives a value from .arg and
+#   silently resolves to its default -- with no build-time indication. That
+#   silent drop is the bug this file fixes.
+#
+# HOW TO USE
+#   Declare the value in .arg with the CUSTOM_ARG_ prefix, and declare the
+#   matching ARG in ./Dockerfile:
+#
+#     # .arg
+#     CUSTOM_ARG_BRAND=acme
+#     CUSTOM_ARG_DHCP_VENDOR_CLASS=retail
+#
+#     # Dockerfile
+#     ARG BRAND
+#     ARG DHCP_VENDOR_CLASS=default-class
+#
+#   Before Earthly runs, inject_custom_build_args() rewrites each matching
+#   `ARG NAME` line so its default becomes the requested value. The upstream
+#   Earthfile is NEVER modified; the original Dockerfile is restored on exit.
+#
+#   Do NOT pass secrets this way -- build args leak into `docker history` and
+#   the build cache. Use the UBUNTU_PRO_KEY / --secret flow instead.
+#
+# FAIL-CLOSED GUARDS (every failure is loud -- the opposite of the old bug)
+#   1. CUSTOM_ARG_<NAME> with no `ARG <NAME>` in the Dockerfile -> ERROR (typo)
+#   2. CUSTOM_ARG_<NAME> where NAME is Earthfile-managed        -> ERROR
+#   3. CUSTOM_ARG_<NAME> with an empty value                    -> ERROR
+#   4. injection did not take effect                            -> ERROR
+#   5. no Dockerfile present                                    -> skip cleanly
+#   6. a custom ARG with no default AND no value, on an
+#      image/iso build target                                   -> ERROR
+#      (same case on a non-Dockerfile target                    -> WARNING)
+#
+# TESTABILITY
+#   Override CANVOS_DOCKERFILE and CANVOS_ARG_FILE to point at fixtures. See
+#   test/custom-build-args_test.sh.
+
+# Args the Earthfile already forwards into the Dockerfile; not user-custom.
+CANVOS_RESERVED_ARGS="${CANVOS_RESERVED_ARGS:-BASE OS_DISTRIBUTION OS_VERSION HTTP_PROXY HTTPS_PROXY NO_PROXY DRBD_VERSION PROXY_CERT_PATH}"
+
+CANVOS_DOCKERFILE="${CANVOS_DOCKERFILE:-./Dockerfile}"
+CANVOS_ARG_FILE="${CANVOS_ARG_FILE:-.arg}"
+CANVOS_DOCKERFILE_BACKUP=""
+
+restore_dockerfile() {
+    if [ -n "$CANVOS_DOCKERFILE_BACKUP" ] && [ -f "$CANVOS_DOCKERFILE_BACKUP" ]; then
+        mv -f "$CANVOS_DOCKERFILE_BACKUP" "$CANVOS_DOCKERFILE"
+        CANVOS_DOCKERFILE_BACKUP=""
+    fi
+}
+
+# Is $1 a target that actually builds the Dockerfile? Every image/iso target
+# pulls +base-image (which does `FROM DOCKERFILE`); utility targets (+go-deps,
+# +uki-genkey, ...) do not.
+is_dockerfile_target() {
+    case "$1" in
+        +*image*|+*iso*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_reserved_arg() {
+    local name="$1" r
+    for r in $CANVOS_RESERVED_ARGS; do
+        [ "$name" = "$r" ] && return 0
+    done
+    return 1
+}
+
+# ARG names declared in the Dockerfile, one per line.
+dockerfile_arg_names() {
+    grep -oE '^[[:space:]]*ARG[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$CANVOS_DOCKERFILE" | awk '{print $2}'
+}
+
+# Does the Dockerfile declare `ARG NAME` with an inline default (`ARG NAME=`)?
+dockerfile_arg_has_default() {
+    grep -qE "^[[:space:]]*ARG[[:space:]]+$1[[:space:]]*=" "$CANVOS_DOCKERFILE"
+}
+
+# CUSTOM_ARG_* keys declared in the .arg file, one per line.
+custom_arg_keys() {
+    [ -f "$CANVOS_ARG_FILE" ] || return 0
+    grep -oE '^[[:space:]]*CUSTOM_ARG_[A-Za-z0-9_]+=' "$CANVOS_ARG_FILE" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*//; s/=$//'
+}
+
+inject_custom_build_args() {
+    local target="${1:-}"
+
+    # Guard 5: no Dockerfile -> nothing to do.
+    [ -f "$CANVOS_DOCKERFILE" ] || return 0
+
+    local dockerfile_args
+    dockerfile_args="$(dockerfile_arg_names)"
+
+    local injected=() defaulted=() key name value esc
+
+    # Validate + inject every CUSTOM_ARG_* declared in .arg (guards 1-4).
+    # Keys come from the .arg file; values come from the sourced env (so any
+    # `$VAR` references in .arg are already resolved by the time we run).
+    while IFS= read -r key; do
+        [ -n "$key" ] || continue
+        name="${key#CUSTOM_ARG_}"
+        value="${!key-}"
+
+        # Guard 2: reserved / Earthfile-managed name.
+        if is_reserved_arg "$name"; then
+            echo >&2 "ERROR: $key targets '$name', which is managed by CanvOS/Earthfile."
+            echo >&2 "       Set it via its normal .arg key ($name=...), not $key."
+            exit 1
+        fi
+        # Guard 1: no matching ARG in the Dockerfile (typo / not declared).
+        if ! printf '%s\n' "$dockerfile_args" | grep -qxF "$name"; then
+            echo >&2 "ERROR: $key is set in .arg but the Dockerfile has no 'ARG $name'."
+            echo >&2 "       Check for a typo, or add 'ARG $name' to the Dockerfile."
+            exit 1
+        fi
+        # Guard 3: empty value.
+        if [ -z "$value" ]; then
+            echo >&2 "ERROR: $key is set but empty. Give it a value, or drop it and use"
+            echo >&2 "       an inline default in the Dockerfile ('ARG $name=...')."
+            exit 1
+        fi
+
+        # Back up the Dockerfile once, and arm the restore trap.
+        if [ -z "$CANVOS_DOCKERFILE_BACKUP" ]; then
+            CANVOS_DOCKERFILE_BACKUP="${CANVOS_DOCKERFILE}.canvos.bak"
+            cp "$CANVOS_DOCKERFILE" "$CANVOS_DOCKERFILE_BACKUP"
+            trap restore_dockerfile EXIT INT TERM
+        fi
+
+        # Escape sed replacement metacharacters (\ & /) in the value.
+        esc="$(printf '%s' "$value" | sed -e 's/[\/&\\]/\\&/g')"
+        # `ARG NAME` or `ARG NAME=old`  ->  `ARG NAME=<value>` (all occurrences).
+        sed -i -E "s|^([[:space:]]*ARG[[:space:]]+${name})([[:space:]]*=.*)?[[:space:]]*\$|\\1=${esc}|" "$CANVOS_DOCKERFILE"
+
+        # Guard 4: confirm the rewrite took effect. A tool built to kill silent
+        # failure must not fail silently itself.
+        if ! grep -qE "^[[:space:]]*ARG[[:space:]]+${name}[[:space:]]*=" "$CANVOS_DOCKERFILE"; then
+            echo >&2 "ERROR: failed to inject a value for '$name' into the Dockerfile."
+            exit 1
+        fi
+        injected+=("$name=$value")
+    done < <(custom_arg_keys)
+
+    # Guard 6: a custom ARG declared in the Dockerfile but never satisfied
+    # (no CUSTOM_ARG_ value AND no inline default) would build empty -- the
+    # exact silent failure that caused this incident.
+    local a i was_injected
+    while IFS= read -r a; do
+        [ -n "$a" ] || continue
+        is_reserved_arg "$a" && continue
+        was_injected=false
+        for i in "${injected[@]}"; do
+            [ "${i%%=*}" = "$a" ] && { was_injected=true; break; }
+        done
+        $was_injected && continue
+        if dockerfile_arg_has_default "$a"; then
+            defaulted+=("$a")
+            continue
+        fi
+        if is_dockerfile_target "$target"; then
+            echo >&2 "ERROR: the Dockerfile declares 'ARG $a' with no default and no value"
+            echo >&2 "       was provided. Set CUSTOM_ARG_$a in .arg, or give it a default"
+            echo >&2 "       ('ARG $a=...'). Refusing to build it silently empty."
+            exit 1
+        else
+            echo >&2 "WARNING: the Dockerfile declares 'ARG $a' with no default and no value;"
+            echo >&2 "         target '$target' does not build the Dockerfile -- continuing."
+        fi
+    done < <(printf '%s\n' "$dockerfile_args")
+
+    # Report what happened -- fixes the original "no build-time indication".
+    if [ ${#injected[@]} -gt 0 ] || [ ${#defaulted[@]} -gt 0 ]; then
+        echo "Custom Docker build args:"
+        [ ${#injected[@]} -gt 0 ]  && echo "  injected:        ${injected[*]}"
+        [ ${#defaulted[@]} -gt 0 ] && echo "  left at default: ${defaulted[*]}"
+    fi
+}

--- a/test/custom-build-args_test.sh
+++ b/test/custom-build-args_test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Unit tests for scripts/custom-build-args.sh (no Docker required).
+#
+# Each case runs inject_custom_build_args in a subshell against fixture
+# Dockerfile / .arg files, so a guard's `exit 1` terminates only that subshell.
+# The mutated Dockerfile is captured mid-run (before the restore trap fires on
+# subshell exit) so injection can be asserted; the fixture is then checked to
+# confirm it was restored byte-for-byte.
+
+set -u
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/scripts/custom-build-args.sh"
+
+PASS=0
+FAIL=0
+
+# run_case <name> <target> <dockerfile-content> <arg-content>
+#   Sets globals: RC, MUTATED (Dockerfile content during the run),
+#   RESTORED (Dockerfile content after the run), OUT (stdout+stderr).
+run_case() {
+    local name="$1" target="$2" dockerfile="$3" argfile="$4"
+    local tmp; tmp="$(mktemp -d)"
+    printf '%s\n' "$dockerfile" > "$tmp/Dockerfile"
+    printf '%s\n' "$argfile"    > "$tmp/.arg"
+    cp "$tmp/Dockerfile" "$tmp/Dockerfile.orig"
+
+    OUT="$( (
+        export CANVOS_DOCKERFILE="$tmp/Dockerfile"
+        export CANVOS_ARG_FILE="$tmp/.arg"
+        # shellcheck disable=SC1090,SC1091
+        source "$LIB"
+        # shellcheck disable=SC1090,SC1091
+        source "$tmp/.arg"        # mimic earthly.sh `source .arg` (sets values)
+        inject_custom_build_args "$target"
+        cp "$CANVOS_DOCKERFILE" "$tmp/Dockerfile.mutated"   # capture mid-run state
+    ) 2>&1 )"
+    RC=$?
+
+    MUTATED="$(cat "$tmp/Dockerfile.mutated" 2>/dev/null || true)"
+    RESTORED="$(cat "$tmp/Dockerfile")"
+    ORIG="$(cat "$tmp/Dockerfile.orig")"
+    BAK_EXISTS=no; [ -f "$tmp/Dockerfile.canvos.bak" ] && BAK_EXISTS=yes
+    LAST_CASE="$name"
+    rm -rf "$tmp"
+}
+
+ok()   { PASS=$((PASS+1)); printf 'PASS: %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL: %s\n    %s\n' "$LAST_CASE" "$1"; }
+
+expect_rc()       { [ "$RC" -eq "$1" ] || bad "expected rc=$1 got rc=$RC (out: $OUT)"; }
+mutated_has()     { printf '%s' "$MUTATED"  | grep -qF "$1" || bad "mutated Dockerfile missing: $1"; }
+restored_equals() { [ "$RESTORED" = "$ORIG" ] || bad "Dockerfile not restored to original"; }
+out_has()         { printf '%s' "$OUT" | grep -qF "$1" || bad "output missing: $1 (out: $OUT)"; }
+bak_gone()        { [ "$BAK_EXISTS" = no ] || bad "backup file was left behind"; }
+
+# 1. Inject into a bare ARG.
+run_case "inject bare ARG" "+iso" "ARG BRAND" "CUSTOM_ARG_BRAND=acme"
+expect_rc 0; mutated_has "ARG BRAND=acme"; restored_equals; bak_gone
+[ "$FAIL" -eq 0 ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 2. Override an existing default.
+run_case "override default" "+iso" "ARG DHCP_VENDOR_CLASS=default-class" "CUSTOM_ARG_DHCP_VENDOR_CLASS=retail"
+expect_rc 0; mutated_has "ARG DHCP_VENDOR_CLASS=retail"; restored_equals
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 3. Typo: CUSTOM_ARG with no matching ARG -> ERROR.
+run_case "typo -> error" "+iso" "ARG BRAND" "CUSTOM_ARG_BRAN=acme"
+expect_rc 1; out_has "no 'ARG BRAN'"; restored_equals
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 4. Reserved / Earthfile-managed name -> ERROR.
+run_case "reserved -> error" "+iso" "ARG BRAND" "CUSTOM_ARG_OS_DISTRIBUTION=rhel"
+expect_rc 1; out_has "managed by CanvOS/Earthfile"
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 5. Empty value -> ERROR.
+run_case "empty value -> error" "+iso" "ARG BRAND" "CUSTOM_ARG_BRAND="
+expect_rc 1; out_has "set but empty"
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 6. Normal Earthfile .arg keys must NOT false-positive.
+run_case "earthfile keys ignored" "+iso" "ARG BRAND=foo" "$(printf 'CUSTOM_TAG=demo\nIMAGE_REGISTRY=ttl.sh\nOS_DISTRIBUTION=ubuntu')"
+expect_rc 0; restored_equals
+printf '%s' "$OUT" | grep -qiE 'ERROR' && bad "false-positive error on normal .arg keys"
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 7. Guard 6: unsatisfied bare ARG on an image target -> ERROR.
+run_case "unsatisfied ARG on image target" "+iso" "ARG BRAND" ""
+expect_rc 1; out_has "Refusing to build it silently empty"
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 8. Guard 6b: same on a non-Dockerfile target -> WARNING, proceeds.
+run_case "unsatisfied ARG on util target" "+go-deps" "ARG BRAND" ""
+expect_rc 0; out_has "WARNING"
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+# 9. Value with sed metacharacters (/ and &) is injected verbatim. Quoted in
+#    .arg so it survives being sourced (CanvOS sources .arg).
+run_case "value with metachars" "+iso" "ARG REGISTRYPATH" 'CUSTOM_ARG_REGISTRYPATH="reg.io/a&b"'
+expect_rc 0; mutated_has "ARG REGISTRYPATH=reg.io/a&b"; restored_equals
+[ "$FAIL" -eq "$FAIL_AT" ] && ok "$LAST_CASE"; FAIL_AT=$FAIL
+
+echo "----------------------------------------"
+echo "PASS: $PASS   FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Issue

Custom Docker build arguments added to `./Dockerfile` never received a value and **silently** fell back to their defaults — with no build-time indication.

- The Earthfile's `base-image` target forwards only a **fixed** `--build-arg` list into the user Dockerfile (`BASE`, `OS_*`, proxies, `DRBD_VERSION`), and Earthly's `FROM DOCKERFILE` cannot forward build args dynamically.
- So a user who added, e.g., `ARG BRAND` / `ARG DHCP_VENDOR_CLASS` to the Dockerfile and set the value in `.arg` got the **default**, not their value.
- **Impact:** per-variant customization (one Dockerfile producing multiple downstream image configurations) was discarded on every build. It surfaced as nodes failing to obtain a DHCP lease and never registering, and could only be detected by inspecting a running node's filesystem — never from the build output.

## Solution

`earthly.sh` now bridges the gap the Earthfile can't: before Earthly runs, it injects `.arg` values into the matching `ARG` defaults of a staged Dockerfile, then restores the original on exit. **The upstream `Earthfile` is not modified** (it survives CanvOS upgrades untouched).

Custom args are declared in `.arg` with a `CUSTOM_ARG_` prefix, which makes intent explicit and lets typos be caught (a plain `.arg` key can't be distinguished from a normal Earthfile arg):

```bash
# .arg
CUSTOM_ARG_BRAND=acme
CUSTOM_ARG_DHCP_VENDOR_CLASS=retail
```
```dockerfile
# Dockerfile (customization section)
ARG BRAND
ARG DHCP_VENDOR_CLASS=default-class
```

The wrapper prints exactly what it did (killing the original "no build-time indication"):
```
Custom Docker build args:
  injected:        BRAND=acme DHCP_VENDOR_CLASS=retail
```

### Fail-closed guards (silent drop → loud error)

| # | Condition | Level |
|---|---|---|
| 1 | `CUSTOM_ARG_<NAME>` with no matching `ARG <NAME>` in the Dockerfile (typo) | **ERROR** |
| 2 | `CUSTOM_ARG_<NAME>` where `<NAME>` is Earthfile-managed (`BASE`, `OS_DISTRIBUTION`, proxies, …) | **ERROR** |
| 3 | `CUSTOM_ARG_<NAME>` with an empty value | **ERROR** |
| 4 | injection did not take effect | **ERROR** |
| 5 | no `./Dockerfile` present | skip cleanly |
| 6 | a custom `ARG` with no default **and** no value, on an image/ISO target | **ERROR** (non-Dockerfile target → **WARNING**) |

Normal Earthfile `.arg` keys (`CUSTOM_TAG`, `ISO_NAME`, `ARCH`, …) are ignored — no false positives. Secrets must **not** be passed this way (build args leak into `docker history` / the build cache); the existing `--secret` flow is unchanged.

### Files
- `scripts/custom-build-args.sh` — sourceable mechanism + guards (new)
- `earthly.sh` — sources the lib and calls `inject_custom_build_args "$1"` before the build (+11 lines)
- `test/custom-build-args_test.sh` — 9 unit tests, no Docker required (new)
- `README.md` — new "Custom Docker Build Arguments" section; corrected the misleading "Earthfile merges custom packages" line
- `.arg.template` — documented `CUSTOM_ARG_` usage

## Manual Test Plan (what was verified)

All run on this branch against a real dev `.arg`.

| Check | Command / action | Result |
|---|---|---|
| Unit tests (all 6 guards) | `bash test/custom-build-args_test.sh` | ✅ `PASS: 9  FAIL: 0` |
| Injection report | `./earthly.sh +base-image` | ✅ prints `Custom Docker build args: injected: BRAND=acme` |
| Typo guard | `CUSTOM_ARG_BRAN=…` with `ARG BRAND` in Dockerfile | ✅ aborts before build: "no 'ARG BRAN'" |
| Reserved guard | `CUSTOM_ARG_OS_DISTRIBUTION=…` | ✅ aborts: "managed by CanvOS/Earthfile" |
| Empty guard | `CUSTOM_ARG_BRAND=` | ✅ aborts: "set but empty" |
| Value reaches the real build | added `ARG BRAND` + `RUN echo "CANVOS-BRAND-CHECK: [$BRAND]"`, ran `+base-image` | ✅ build log shows `CANVOS-BRAND-CHECK: [acme]` |
| Injected Dockerfile builds | full `./earthly.sh +base-image` | ✅ `🌍 Earthly Build ✅ SUCCESS` (exit 0) |
| Auto-restore | inspect `./Dockerfile` after the run | ✅ restored to original; no `Dockerfile.canvos.bak` left behind |

The contrast case (plain `BRAND=…` without the prefix) reproduces the old empty-value behavior, confirming why the mechanism is needed.

## Notes
- Pre-existing, unrelated: `fatal: No tags can describe …` from `git describe` in `earthly.sh` on a branch with no reachable tags — harmless (only affects the version tag on a full build).
