### PR TITLE
fix: prevent CIS+TWO_NODE postgresql install hang

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -868,6 +868,7 @@ provider-image:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y lsb-release && \
                 echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
                 apt-get update && \
+                usermod -aG sudo root && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-16 postgresql-contrib-16 iputils-ping
         ELSE IF [ "$OS_DISTRIBUTION" = "opensuse-leap" ] && [ "$ARCH" = "amd64" ]
             RUN zypper --non-interactive --quiet addrepo --refresh -p 90 http://download.opensuse.org/repositories/server:database:postgresql/openSUSE_Tumbleweed/ PostgreSQL && \


### PR DESCRIPTION
## Summary
- Two-node provider images with `CIS_HARDENING=true` hung forever on an interactive `Password:` prompt while installing `postgresql-16`.
- CIS `harden.sh` requires `su` callers to be in the `sudo` group; root is not a member in the build container, so postgres postinst (`su postgres`) blocked.
- Add `usermod -aG sudo root` immediately before the Ubuntu postgres install so `pam_wheel` allows the noninteractive `su`. Harmless when CIS hardening is off.

## Test plan
- [ ] Build a provider image with `TWO_NODE=true` and `CIS_HARDENING=true` and confirm the postgres install completes (no hang at "Setting up postgresql-common").
- [ ] Build with `TWO_NODE=true` and `CIS_HARDENING=false` and confirm the postgres install still succeeds.
