### PR TITLE
feat: enable qemu-guest-agent in Ubuntu Dockerfile customizations (backport #799)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,14 @@ COPY overlay/files/etc/spectrocloud/custom-hardware-specs-lookup.json /etc/spect
 #    apt-get install iputils-ping -y && \
 #    mkdir /var/lib/wpa
 
-# Ubuntu / Debian
-#RUN if [ "${OS_DISTRIBUTION}" = "ubuntu" ]; then \
-#      apt-get install -y qemu-guest-agent; \
-#    fi
+# Install qemu-guest-agent for Ubuntu (needed for VM guest integration on
+# provider images and slim/installer ISOs built via +base-image).
+RUN if [ "${OS_DISTRIBUTION}" = "ubuntu" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends qemu-guest-agent && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 ### To install the DRBD module package for Piraeus pack on Ubuntu  ###
 


### PR DESCRIPTION
## Summary

Backport of #799 to `rc-4.10`.

- Uncomments and enhances the `qemu-guest-agent` installation block for Ubuntu in `Dockerfile`
- Follows Docker best practices: `apt-get update` before install, `--no-install-recommends`, and cleanup of apt lists
- Installation is gated on `OS_DISTRIBUTION=ubuntu` (no impact on other distros)
- Adds comment documenting the purpose: VM guest integration on provider images and slim/installer ISOs built via `+base-image`

## Test plan

- [ ] Verify `qemu-guest-agent` is present in non-FIPS Ubuntu ISO installer rootfs
- [ ] Verify installation in provider image builds
- [ ] Confirm other OS distributions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)