### PR TITLE
patch: prevent CIS+TWO_NODE postgresql install hang (backport #804 to rc-4.9)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -638,6 +638,7 @@ provider-image:
                 curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
                 echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
                 apt-get update && \
+                usermod -aG sudo root && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-16 postgresql-contrib-16 iputils-ping
         ELSE IF [ "$OS_DISTRIBUTION" = "opensuse-leap" ] && [ "$ARCH" = "amd64" ]
             RUN zypper --non-interactive --quiet addrepo --refresh -p 90 http://download.opensuse.org/repositories/server:database:postgresql/openSUSE_Tumbleweed/ PostgreSQL && \


### PR DESCRIPTION
Backport of #804 to `rc-4.9`.

## Summary
- Adds `usermod -aG sudo root` before installing `postgresql-16` so `pam_wheel` does not block `su postgres` with an interactive password prompt during CIS+TWO_NODE builds.

## Original PR
https://github.com/spectrocloud/CanvOS/pull/804