### PR TITLE
PE-9383: fix(cis-harden) insert pam_wheel after pam_rootok.so instead of prep…

### DIFF
--- a/cis-harden/harden.sh
+++ b/cis-harden/harden.sh
@@ -1067,9 +1067,19 @@ harden_auth() {
 		config_lines="auth required pam_wheel.so use_uid"
 	fi
 
-	# Add configuration lines to the top of the file
+	# Insert the wheel restriction AFTER pam_rootok.so, not before it.
+	# PAM discards a `sufficient` success once a prior `required` module has
+	# already failed, so prepending above pam_rootok denies root and hangs any
+	# `su` invoked in a non-interactive build (e.g. the postgresql-16 postinst
+	# when TWO_NODE=true). Ubuntu's own comments name this exact trap. See PE-9383.
 	if [[ -f /etc/pam.d/su ]]; then
-		echo -e "$config_lines\n$(cat /etc/pam.d/su)" > /etc/pam.d/su
+		if grep -qE '^[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_rootok\.so' /etc/pam.d/su; then
+			awk -v L="$config_lines" \
+				'{print} /^[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_rootok\.so/ && !done {print L; done=1}' \
+				/etc/pam.d/su > /etc/pam.d/su.new && mv /etc/pam.d/su.new /etc/pam.d/su
+		else
+			echo -e "$config_lines\n$(cat /etc/pam.d/su)" > /etc/pam.d/su
+		fi
 		echo "Configuration to ensure access to the su command is restricted have been made"
 	fi
 


### PR DESCRIPTION


Prepending `auth required pam_wheel.so` above `auth sufficient pam_rootok.so` causes PAM to discard root's unconditional bypass: a `sufficient` success is ignored once a prior `required` module has already failed. During a CIS_HARDENING=true + TWO_NODE=true build, the postgresql-16 postinst runs `su postgres`, hits the broken stack, and blocks forever on an interactive password prompt (PE-9383 / SUS-1975).

Use awk to anchor the insertion immediately after the pam_rootok.so line. If the anchor is absent (non-standard file), fall back to the previous prepend so existing non-Ubuntu flows are unaffected.

The security posture is unchanged: pam_rootok already grants root unconditionally by design; the wheel rule below it still blocks every non-root user from su.

# This allows root to su without passwords (normal operation)
auth       sufficient pam_rootok.so
auth required pam_wheel.so use_uid group=sudo