### PR TITLE
Revert "fix: prevent CIS+TWO_NODE postgresql install hang (#804)"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -868,7 +868,6 @@ provider-image:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y lsb-release && \
                 echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
                 apt-get update && \
-                usermod -aG sudo root && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-16 postgresql-contrib-16 iputils-ping
         ELSE IF [ "$OS_DISTRIBUTION" = "opensuse-leap" ] && [ "$ARCH" = "amd64" ]
             RUN zypper --non-interactive --quiet addrepo --refresh -p 90 http://download.opensuse.org/repositories/server:database:postgresql/openSUSE_Tumbleweed/ PostgreSQL && \


### PR DESCRIPTION
## Summary
Reverts #804. The `usermod -aG sudo root` workaround is superseded by #818, which fixes the root cause in `cis-harden/harden.sh` (inserting the wheel restriction **after** `pam_rootok.so` instead of prepending it, so root's `sufficient` bypass is preserved).

Keeping #804 alongside #818 would:
- ship an image with root in the `sudo` group on every hardened build, weakening the CIS control the harden step exists to apply;
- leave a one-call-site patch in the Earthfile that duplicates fixed behaviour and reads as load-bearing when it isn't.

JIRA: [PE-9383](https://spectrocloud.atlassian.net/browse/PE-9383)

## Merge order
⛔ Do **not** merge until #818 is merged to `main`. This PR is intentionally opened as **draft**.

## Test plan
- [ ] Build a provider image with `TWO_NODE=true CIS_HARDENING=true` after #818 lands and confirm the postgres install completes (no hang at "Setting up postgresql-common").
- [ ] Build with `TWO_NODE=true CIS_HARDENING=false` and confirm the postgres install still succeeds.
- [ ] On the resulting hardened image, verify `id root` shows no `sudo` group membership.


[PE-9383]: https://spectrocloud.atlassian.net/browse/PE-9383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ