### PR TITLE
Revert "fix: prevent CIS+TWO_NODE postgresql install hang (#804) (#813)"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -868,7 +868,6 @@ provider-image:
                 DEBIAN_FRONTEND=noninteractive apt-get install -y lsb-release && \
                 echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
                 apt-get update && \
-                usermod -aG sudo root && \
                 DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-16 postgresql-contrib-16 iputils-ping
         ELSE IF [ "$OS_DISTRIBUTION" = "opensuse-leap" ] && [ "$ARCH" = "amd64" ]
             RUN zypper --non-interactive --quiet addrepo --refresh -p 90 http://download.opensuse.org/repositories/server:database:postgresql/openSUSE_Tumbleweed/ PostgreSQL && \


### PR DESCRIPTION
## Summary
Reverts #813 on `rc-4.10` (backport of #804 on main). Same rationale as the main-branch revert: the `usermod -aG sudo root` workaround is superseded by the proper PAM ordering fix in #818, which needs to be backported to `rc-4.10` alongside this revert.

Keeping the workaround on the release branch would ship 4.10 images with root in the `sudo` group whenever CIS hardening is on — the exact posture the harden step is meant to prevent.

JIRA: [PE-9383](https://spectrocloud.atlassian.net/browse/PE-9383)

## Merge order
⛔ Do **not** merge until #818 (or its rc-4.10 backport) has landed on `rc-4.10`. This PR is intentionally opened as **draft**.

## Test plan
- [ ] Build a provider image on `rc-4.10` with `TWO_NODE=true CIS_HARDENING=true` (after the #818 backport) and confirm the postgres install completes.
- [ ] Build with `TWO_NODE=true CIS_HARDENING=false` and confirm the postgres install still succeeds.
- [ ] On the resulting hardened image, verify `id root` shows no `sudo` group membership.


[PE-9383]: https://spectrocloud.atlassian.net/browse/PE-9383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ