### PR TITLE
fix(cis-harden): insert pam_wheel after pam_rootok.so instead of prepending [backport rc-4.9]

### DIFF
--- a/cis-harden/harden.sh
+++ b/cis-harden/harden.sh
@@ -1067,9 +1067,19 @@ harden_auth() {
 		config_lines="auth required pam_wheel.so use_uid"
 	fi
 
-	# Add configuration lines to the top of the file
+	# Insert the wheel restriction AFTER pam_rootok.so, not before it.
+	# PAM discards a `sufficient` success once a prior `required` module has
+	# already failed, so prepending above pam_rootok denies root and hangs any
+	# `su` invoked in a non-interactive build (e.g. the postgresql-16 postinst
+	# when TWO_NODE=true). Ubuntu's own comments name this exact trap. See PE-9383.
 	if [[ -f /etc/pam.d/su ]]; then
-		echo -e "$config_lines\n$(cat /etc/pam.d/su)" > /etc/pam.d/su
+		if grep -qE '^[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_rootok\.so' /etc/pam.d/su; then
+			awk -v L="$config_lines" \
+				'{print} /^[[:space:]]*auth[[:space:]]+sufficient[[:space:]]+pam_rootok\.so/ && !done {print L; done=1}' \
+				/etc/pam.d/su > /etc/pam.d/su.new && mv /etc/pam.d/su.new /etc/pam.d/su
+		else
+			echo -e "$config_lines\n$(cat /etc/pam.d/su)" > /etc/pam.d/su
+		fi
 		echo "Configuration to ensure access to the su command is restricted have been made"
 	fi
 


### PR DESCRIPTION
## Summary

Backport of #818 to `rc-4.9`.

- Fixes PAM configuration for CIS hardening: inserts `pam_wheel` after `pam_rootok.so` instead of prepending it to the file.

## Original PR

https://github.com/spectrocloud/CanvOS/pull/818

🤖 Generated with [Claude Code](https://claude.com/claude-code)