### PR TITLE
feat(earthly): add KERNEL_VERSION build arg for pinned Ubuntu kernel installs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -84,6 +84,7 @@ ARG https_proxy=${HTTPS_PROXY}
 ARG no_proxy=${NO_PROXY}
 
 ARG UPDATE_KERNEL=false
+ARG KERNEL_VERSION
 
 # NVIDIA GPU driver pre-install (for air-gapped GPU Operator with driver.enabled=false).
 # When true, the NVIDIA data-center driver + DKMS kernel modules are baked into the
@@ -988,6 +989,15 @@ base-image:
         IF [ "$UPDATE_KERNEL" = "false" ]
             RUN if dpkg -l "linux-image-generic-hwe-$OS_VERSION" > /dev/null; then apt-mark hold "linux-image-generic-hwe-$OS_VERSION" "linux-headers-generic-hwe-$OS_VERSION" "linux-generic-hwe-$OS_VERSION" ; fi && \
                 if dpkg -l linux-image-generic > /dev/null; then apt-mark hold linux-image-generic linux-headers-generic linux-generic; fi
+        ELSE IF [ -n "$KERNEL_VERSION" ]
+            SET APT_UPGRADE_FLAGS="-y --with-new-pkgs"
+            RUN export DEBIAN_FRONTEND=noninteractive && \
+                apt-get update && \
+                apt-get install -y \
+                    linux-image-${KERNEL_VERSION}-generic \
+                    linux-modules-${KERNEL_VERSION}-generic \
+                    linux-modules-extra-${KERNEL_VERSION}-generic \
+                    linux-headers-${KERNEL_VERSION}-generic
         ELSE
             SET APT_UPGRADE_FLAGS="-y --with-new-pkgs"
             RUN export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
## Summary

- Adds a new `KERNEL_VERSION` build arg (empty by default, no-op unless passed)
- When `UPDATE_KERNEL=true` and `KERNEL_VERSION=<ver>` is set, installs the exact kernel packages (`linux-image-<ver>-generic`, `linux-modules-*`, `linux-headers-*`) instead of the latest HWE kernel
- Preserves existing behaviour: `UPDATE_KERNEL=false` holds/pins the current kernel; `UPDATE_KERNEL=true` without `KERNEL_VERSION` still installs `linux-image-generic-hwe-$OS_VERSION`

## Motivation

`UPDATE_KERNEL=true` currently pulls the latest HWE kernel, which can push the kernel version above a desired boundary (e.g. 7.x when 6.x is required). This arg gives callers explicit control.

## Usage

```bash
./earthly.sh +build-all-images --ARCH=amd64 --UPDATE_KERNEL=true --KERNEL_VERSION=6.18.0-51
```

## Test plan

- [ ] Build with `UPDATE_KERNEL=false` — kernel should be held as before
- [ ] Build with `UPDATE_KERNEL=true` and no `KERNEL_VERSION` — should install `linux-image-generic-hwe-$OS_VERSION` as before
- [ ] Build with `UPDATE_KERNEL=true --KERNEL_VERSION=6.18.0-51` — should install the pinned 6.18.0-51 kernel packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)