### PR TITLE
fix(cis-harden): keep rpcbind in Level 2 remove list so nfs-common survives (PE-9505)

### DIFF
--- a/cis-harden/harden.sh
+++ b/cis-harden/harden.sh
@@ -692,7 +692,7 @@ remove_services() {
 
 		# CIS Level 2 - Additional packages to remove
 		echo "Removing additional CIS Level 2 packages"
-		apt-get remove -y avahi-daemon cups rpcbind nfs-kernel-server vsftpd apache2 nginx samba squid snmpd 2>/dev/null || true
+		apt-get remove -y avahi-daemon cups nfs-kernel-server vsftpd apache2 nginx samba squid snmpd 2>/dev/null || true
 
 		# CIS Level 2 - Disable additional services
 		echo "Disabling additional CIS Level 2 services"


### PR DESCRIPTION
## Summary

CIS-hardened Edge builds silently lose the NFS client stack: `harden.sh:695` removes `rpcbind` in the CIS Level 2 package cleanup, and since `nfs-common` hard-Depends on rpcbind, apt cascades `nfs-common` (and `/sbin/mount.nfs`) out in the same transaction. The `2>/dev/null || true` wrapper hides the loss at build time.

Consequence on hardened nodes: every host-side NFS mount fails with exit 32 ("you might need a /sbin/mount.<type> helper program"). Longhorn serves all RWX volumes over NFS via share-manager, so `zot-0` stays stuck in `ContainerCreating`, the in-cluster registry (VIP:30003) never comes up, and every pack hits `ImagePullBackOff` — day-1 bring-up fails.

Ticket: [PE-9505](https://spectrocloud.atlassian.net/browse/PE-9505)

## Fix

Drop `rpcbind` from the Level 2 remove list. One line.

The security intent is preserved without the package removal:
- `systemctl disable rpcbind` + `systemctl mask rpcbind.service rpcbind.socket` (harden.sh:701, :875–876) remain — the portmapper stays off the wire.
- `nfs-kernel-server` (the NFS *server*) is still removed — only the client stack survives.
- NFSv4 mounts (`vers=4.1`, what Longhorn uses) don't use rpcbind on the wire at all; they only need the `mount.nfs` binary.
- CIS Level 1 explicitly permits client tools on hosts that mount NFS.

## Validation

Artifact-level check of the built installer's rootfs (`build/palette-edge-installer.iso`, post-fix build):
- Hardening confirmed to have run: audit rules files written by harden.sh (`50-time-change.rules`, `50-identity.rules`, `50-access.rules`, `50-delete.rules`, `50-mounts.rules`, `50-scope.rules`) present in the squashfs.
- `/usr/sbin/mount.nfs` present — nfs-common survived.
- `/usr/sbin/rpcbind` present — the discriminator: a pre-fix hardened build cascade-removed rpcbind (and nfs-common with it).

Remaining: lab/BDD CIS=true stack bring-up with zot going Ready (end-to-end proof).

## Test plan

- [ ] Rebuild with `CIS_HARDENING=true`, verify `dpkg -l nfs-common` = `ii` and `/sbin/mount.nfs` exists in the image
- [ ] Deploy the two-node harbor-zot appliance stack with CIS hardening = true; `zot-0` goes Ready, packs pull from VIP:30003
- [ ] Confirm CIS scan posture: rpcbind.service/socket still masked/disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PE-9505]: https://spectrocloud.atlassian.net/browse/PE-9505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ