### PR TITLE
chore: bump pe version to v4.10.4-rc.4

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -20,7 +20,7 @@ ARG SPECTRO_LUET_REPO=us-docker.pkg.dev/palette-images/edge
 ARG KAIROS_BASE_IMAGE_URL=$SPECTRO_PUB_REPO/edge
 
 # Spectro Cloud and Kairos tags.
-ARG PE_VERSION=v4.10.4-rc.3
+ARG PE_VERSION=v4.10.4-rc.4
 ARG KAIROS_VERSION=v4.1.2
 # Version component of the base image tags produced by .github/workflows/base-images.yaml.
 # Those images are tagged with the kairos-init version, so this must track the


### PR DESCRIPTION
Automated PE version bump from [stylus](https://github.com/spectrocloud/stylus) release `v4.10.4-rc.4`.

Target branch: `rc-4.10`